### PR TITLE
Fix Claude Code compatibility by updating MCP initialization

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -17,7 +17,7 @@ pub struct NushellTool {
 }
 
 impl ServerHandler for NushellTool {
-    fn get_info(&self) -> ServerInfo {
+    fn get_info(&self) -> InitializeResult {
         let mut instructions = String::from("MCP server exposing Nushell commands.\n");
 
         instructions.push_str("Allowed commands (always permitted):\n");
@@ -43,9 +43,17 @@ impl ServerHandler for NushellTool {
             if self.config.allow_sudo { "yes" } else { "no" }
         ));
 
-        ServerInfo {
+        InitializeResult {
+            protocol_version: ProtocolVersion::LATEST,
+            capabilities: ServerCapabilities {
+                tools: Some(ToolsCapability::default()),
+                ..Default::default()
+            },
+            server_info: Implementation {
+                name: "nu-mcp".to_string(),
+                version: env!("CARGO_PKG_VERSION").to_string(),
+            },
             instructions: Some(instructions),
-            ..Default::default()
         }
     }
 


### PR DESCRIPTION
## Summary
- Updates `get_info()` method to return `InitializeResult` instead of `ServerInfo`
- Adds explicit protocol version declaration (`ProtocolVersion::LATEST`)
- Includes proper capabilities negotiation with tools support
- Adds server implementation details (name and version)

## Problem
Claude Code was unable to work with nu-mcp while other LLM clients worked fine. Analysis showed that Claude Code expects stricter MCP protocol compliance during the initialization handshake.

## Solution
Changed the implementation to match the pattern used by working MCP servers like c67-mcp, which properly declares protocol version and capabilities during initialization.

## Test plan
- [x] Code compiles successfully
- [x] All existing tests pass
- [x] Built release binary without errors