### PR TITLE
Fix tmux list_sessions schema ambiguity

### DIFF
--- a/tools/tmux/mod.nu
+++ b/tools/tmux/mod.nu
@@ -22,6 +22,7 @@ def "main list-tools" [] {
       input_schema: {
         type: "object"
         properties: {}
+        additionalProperties: false
       }
     }
     {


### PR DESCRIPTION
## Summary
- Add `additionalProperties: false` to tmux `list_sessions` tool schema to eliminate ambiguity for LLMs

## Problem
The `list_sessions` tool had schema `{"type": "object", "properties": {}}` which is ambiguous - LLMs might send empty `{}`, nothing at all, or get confused about expected input.

## Solution
Added `additionalProperties: false` to make it explicit that this tool accepts an empty object with no additional properties allowed.