### PR TITLE
feat: Add Homebrew formula and update release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: Multi-Arch Nix Release (v2)
+name: Release
 
 on:
   workflow_dispatch:
@@ -19,7 +19,7 @@ jobs:
       version: ${{ steps.prep.outputs.version }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ github.ref }}
@@ -54,7 +54,7 @@ jobs:
             nix_system: aarch64-linux
     steps:
       - name: Checkout release branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: release/${{ needs.prep-release.outputs.version }}
 
@@ -72,7 +72,7 @@ jobs:
           cp result/nu-mcp-nix.sha256 ${{ github.workspace }}/nu-mcp-${{ needs.prep-release.outputs.version }}-${{ matrix.nix_system }}-nix.sha256
 
       - name: Upload build outputs as artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: nu-mcp-assets-${{ matrix.nix_system }}
           path: |
@@ -93,7 +93,7 @@ jobs:
           private-key: ${{ secrets.BOT }}
 
       - name: Checkout release branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: release/${{ needs.prep-release.outputs.version }}
           fetch-depth: 0
@@ -103,7 +103,7 @@ jobs:
         uses: ck3mp3r/actions/nu-tools@main
 
       - name: Download all build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           path: ./artifacts
 
@@ -118,6 +118,27 @@ jobs:
           # Generate platform data and commit
           generate-platform-data-for $version "nu-mcp" "./artifacts" | commit-files $"Add platform data for release ($version)"
 
+          # Prepare architecture data with hashes
+          let architectures = [
+            {
+              name: "aarch64-darwin"
+              hash: (open $"./artifacts/nu-mcp-assets-aarch64-darwin/nu-mcp-($version)-aarch64-darwin.sha256" | str trim)
+            }
+            {
+              name: "aarch64-linux"
+              hash: (open $"./artifacts/nu-mcp-assets-aarch64-linux/nu-mcp-($version)-aarch64-linux.sha256" | str trim)
+            }
+            {
+              name: "x86_64-linux"
+              hash: (open $"./artifacts/nu-mcp-assets-x86_64-linux/nu-mcp-($version)-x86_64-linux.sha256" | str trim)
+            }
+          ]
+
+          # Update Homebrew formula
+          open Formula/nu-mcp.rb | update-homebrew-formula $version "nu-mcp" $architectures | save --force Formula/nu-mcp.rb
+          git add Formula/nu-mcp.rb
+          git commit -m $"Update Homebrew formula to ($version)"
+
           # Create release and upload artifacts using gh CLI
           create-github-release $version
           glob "./artifacts/**/*.*" | upload-release-artifacts $version
@@ -126,4 +147,3 @@ jobs:
           merge-and-cleanup $version
         env:
           GITHUB_TOKEN: ${{ steps.token.outputs.token }}
-

--- a/Formula/nu-mcp.rb
+++ b/Formula/nu-mcp.rb
@@ -1,0 +1,30 @@
+class NuMcp < Formula
+  desc "nu-mcp - Model Context Protocol (MCP) Server for Nushell"
+  homepage "https://github.com/ck3mp3r/nu-mcp"
+  version "0.3.8"
+
+  depends_on "nushell"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "https://github.com/ck3mp3r/nu-mcp/releases/download/v0.3.8/nu-mcp-0.3.8-aarch64-darwin.tgz"
+      sha256 "b109c02ddd219b050d45e9b469962185706f887a4cb44b7288ab8d3b0c04e024"
+    else
+      odie "Intel Macs are no longer supported. Please use an Apple Silicon Mac."
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.intel?
+      url "https://github.com/ck3mp3r/nu-mcp/releases/download/v0.3.8/nu-mcp-0.3.8-x86_64-linux.tgz"
+      sha256 "51f306ece35e7012ecb7496b268ff5d7e02f8e747052d0bf42633ea98503bb4a"
+    elsif Hardware::CPU.arm?
+      url "https://github.com/ck3mp3r/nu-mcp/releases/download/v0.3.8/nu-mcp-0.3.8-aarch64-linux.tgz"
+      sha256 "9dd75b06f05ee04144666297a2db08f8ba8ae9c86b9a327e988bec565864a0c5"
+    end
+  end
+
+  def install
+    bin.install "nu-mcp"
+  end
+end

--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ For detailed configuration options and tool development, see the [documentation]
 
 ## Installation
 
-### As a Nix profile (standalone usage)
+### Via Nix
+
+#### As a Nix profile (standalone usage)
 
 You can install this flake as a Nix profile:
 
@@ -69,11 +71,11 @@ Or, if you have a local checkout:
 nix profile install path:/absolute/path/to/nu-mcp
 ```
 
-### Installing Tools
+#### Installing Tools
 
 Tools are available as individual packages or as a complete collection:
 
-#### Individual Tools
+##### Individual Tools
 ```sh
 # Weather tool only
 nix profile install github:ck3mp3r/nu-mcp#weather-mcp-tools
@@ -85,7 +87,7 @@ nix profile install github:ck3mp3r/nu-mcp#finance-mcp-tools
 nix profile install github:ck3mp3r/nu-mcp#tmux-mcp-tools
 ```
 
-#### Complete Tool Collection
+##### Complete Tool Collection
 ```sh
 # All available tools
 nix profile install github:ck3mp3r/nu-mcp#mcp-tools
@@ -93,7 +95,7 @@ nix profile install github:ck3mp3r/nu-mcp#mcp-tools
 
 Tools are installed to `~/.nix-profile/share/nushell/mcp-tools/`.
 
-### As an overlay in your own flake
+#### As an overlay in your own flake
 
 Add this flake as an input and overlay in your `flake.nix`:
 
@@ -113,6 +115,21 @@ Add this flake as an input and overlay in your `flake.nix`:
 ```
 
 You can now use `pkgs.nu-mcp` in your own packages, devShells, or CI.
+
+### Via Homebrew (macOS and Linux)
+
+Install from the tap:
+
+```sh
+brew tap ck3mp3r/nu-mcp https://github.com/ck3mp3r/nu-mcp
+brew install nu-mcp
+```
+
+Or install directly:
+
+```sh
+brew install ck3mp3r/nu-mcp/nu-mcp
+```
 
 ## Development
 - See [modelcontextprotocol/rust-sdk](https://github.com/modelcontextprotocol/rust-sdk) for SDK details and advanced usage.


### PR DESCRIPTION
This PR introduces a Homebrew formula for nu-mcp and updates the release workflow to automate formula updates and artifact handling.

## Details
- Added `Formula/nu-mcp.rb` to provide a Homebrew installation method for nu-mcp, supporting Apple Silicon Macs and Linux (x86_64 and ARM).
- Updated `.github/workflows/release.yaml`:
  - Renamed workflow to "Release" for clarity.
  - Upgraded GitHub Actions versions (checkout, upload-artifact, download-artifact) for improved reliability and features.
  - Automated Homebrew formula updates by extracting architecture-specific hashes from build artifacts and updating `Formula/nu-mcp.rb` during the release process.
  - Improved artifact management and release creation steps.
- The formula includes platform-specific URLs and SHA256 hashes for each supported architecture, ensuring secure and accurate installations.

## Context
This change streamlines the release process by integrating Homebrew support and automating formula updates, making it easier for users to install nu-mcp and for maintainers to publish new versions. The workflow improvements also enhance maintainability and future extensibility.