### PR TITLE
docs: Remove broken brew install instruction from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,12 +125,6 @@ brew tap ck3mp3r/nu-mcp https://github.com/ck3mp3r/nu-mcp
 brew install nu-mcp
 ```
 
-Or install directly:
-
-```sh
-brew install ck3mp3r/nu-mcp/nu-mcp
-```
-
 ## Development
 - See [modelcontextprotocol/rust-sdk](https://github.com/modelcontextprotocol/rust-sdk) for SDK details and advanced usage.
 - The code is modular and fully async.


### PR DESCRIPTION
This PR updates the README by removing a non-functional brew install command to prevent confusion for users.

## Details
- The following broken instruction was deleted from README.md:
  ```
  brew install ck3mp3r/nu-mcp/nu-mcp
  ```
- Only README.md was modified; no code changes were made.
- The change ensures users follow the correct installation steps and improves documentation clarity.

## Context
The removed command was not working as intended and could mislead users attempting to install via Homebrew. This update streamlines the installation instructions and maintains documentation accuracy.