### PR TITLE
docs(argocd): Clarify argocd CLI is required at runtime

### DIFF
--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -8,8 +8,7 @@
     pname = "argocd-mcp-tools";
     src = ../tools/argocd;
     installPath = "argocd";
-    description = "ArgoCD MCP tool for nu-mcp - provides ArgoCD application and resource management via HTTP API";
-    propagatedBuildInputs = [pkgs.argocd];
+    description = "ArgoCD MCP tool for nu-mcp - provides ArgoCD application and resource management via HTTP API. Requires argocd CLI to be installed and on PATH.";
   };
 
   weather-mcp-tools = mkToolPackage {

--- a/tools/argocd/README.md
+++ b/tools/argocd/README.md
@@ -11,7 +11,9 @@ MCP server for ArgoCD with automatic discovery and CLI-based authentication.
 
 ## Requirements
 
-- **ArgoCD CLI** (`argocd`) - Must be installed and in PATH
+**Critical**: These tools will **NOT work** without the ArgoCD CLI installed and available on PATH.
+
+- **ArgoCD CLI** (`argocd`) - **REQUIRED** - Must be installed and on PATH at runtime
 - **kubectl** - For Kubernetes cluster access
 - **Kubernetes Cluster** - With ArgoCD installed
 
@@ -25,9 +27,15 @@ brew install argocd
 curl -sSL -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64
 chmod +x /usr/local/bin/argocd
 
+# Nix / NixOS
+nix-shell -p argocd
+# Or add to your environment
+
 # Verify installation
 argocd version
 ```
+
+**Note**: If using via Nix devenv (this repository), `argocd` is automatically available in the shell.
 
 ## How It Works
 


### PR DESCRIPTION
## Summary

Clarifies that the ArgoCD CLI must be installed and available on PATH at runtime for the ArgoCD tools to work.

## Problem

The `propagatedBuildInputs` in the Nix package gave a false impression that dependencies would be automatically available. In reality, when nu-mcp spawns Nushell processes to execute tool scripts, those scripts call external commands like `argocd login` which must be on PATH.

## Changes

1. **Removed `propagatedBuildInputs`** from `argocd-mcp-tools` package
   - It doesn't help at runtime
   - Only useful for compile-time dependencies
   
2. **Updated package description** to explicitly mention CLI requirement

3. **Enhanced README** to make requirement crystal clear:
   - Added "Critical" section at top of Requirements
   - Added Nix installation instructions
   - Noted that devenv already includes argocd

## Why This Approach

- nu-mcp discovers tools dynamically - can't wrap for all permutations
- Matches how k8s tools work (require kubectl/helm to be installed)
- Users are already expected to install external dependencies
- The devenv includes argocd for development
- This is the standard pattern for tools that call external commands

## Breaking Changes

None. This is just documentation clarification. The requirement was always there, just not clearly stated.
