### PR TITLE
Fix tool output formats and improve ArgoCD discovery

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -12,14 +12,24 @@ nu -c "use utils.nu *; calculate_price_change 100.0 95.0"
 ```
 
 ## Testing Complete Tools
+
+**CRITICAL**: Always test using the `call-tool` function, NOT by calling internal functions directly!
+
 ```bash
 # Test tool discovery
 nu tools/weather/mod.nu list-tools
 
-# Test tool execution
+# Test tool execution - ALWAYS use call-tool
 nu tools/weather/mod.nu call-tool get_weather '{"location": "London"}'
 nu tools/finance/mod.nu call-tool get_ticker_price '{"symbol": "AAPL"}'
+nu tools/argocd/mod.nu call-tool list_applications '{"namespace": "argocd"}'
+
+# WRONG - Do not call internal functions directly for testing
+# nu -c "use tools/argocd/cluster.nu *; resolve {server: 'https://localhost:8080'}"
+# This bypasses the actual tool flow and may give false results
 ```
+
+The `call-tool` function is the entry point that mimics how the MCP server will invoke tools. Testing internal functions directly may give different results than actual tool execution.
 
 ## Integration Testing
 ```bash

--- a/tools/argocd/README.md
+++ b/tools/argocd/README.md
@@ -45,6 +45,8 @@ argocd version
 4. **Token Management**: ArgoCD CLI stores tokens in `~/.argocd/config`
 5. **API Calls**: Makes HTTP API calls using CLI-managed tokens
 
+**IMPORTANT**: When providing a `server` parameter to any tool, it is assumed the user has already logged in via `argocd login`. The tools will use the existing CLI session. If auto-discovery finds an in-cluster URL (*.svc.cluster.local), you must set up port-forward first, have the user login via `argocd login`, then provide the localhost server URL.
+
 ## Credential Discovery
 
 The tool automatically discovers credentials using these strategies (in order):

--- a/tools/argocd/applications.nu
+++ b/tools/argocd/applications.nu
@@ -73,7 +73,7 @@ export def list-applications [
       hasMore: (($limit != null) and ($limit < ($all_items | length)))
       summarized: $should_summarize
     }
-  }
+  } | to json --indent 2
 }
 
 # Get application details
@@ -88,7 +88,7 @@ export def get-application [
     $params = ($params | insert appNamespace $app_namespace)
   }
 
-  api-request "get" $"/api/v1/applications/($name)" $instance --params $params
+  api-request "get" $"/api/v1/applications/($name)" $instance --params $params | to json --indent 2
 }
 
 # Get application resource tree
@@ -96,7 +96,7 @@ export def get-application-resource-tree [
   instance: record # ArgoCD instance
   name: string # Application name
 ] {
-  api-request "get" $"/api/v1/applications/($name)/resource-tree" $instance
+  api-request "get" $"/api/v1/applications/($name)/resource-tree" $instance | to json --indent 2
 }
 
 # Get application events
@@ -104,7 +104,7 @@ export def get-application-events [
   instance: record # ArgoCD instance
   name: string # Application name
 ] {
-  api-request "get" $"/api/v1/applications/($name)/events" $instance
+  api-request "get" $"/api/v1/applications/($name)/events" $instance | to json --indent 2
 }
 
 # Create a new application
@@ -112,7 +112,7 @@ export def create-application [
   instance: record # ArgoCD instance
   application: record # Application specification
 ] {
-  api-request "post" "/api/v1/applications" $instance --body $application
+  api-request "post" "/api/v1/applications" $instance --body $application | to json --indent 2
 }
 
 # Update an existing application
@@ -121,7 +121,7 @@ export def update-application [
   name: string # Application name
   application: record # Updated application specification
 ] {
-  api-request "put" $"/api/v1/applications/($name)" $instance --body $application
+  api-request "put" $"/api/v1/applications/($name)" $instance --body $application | to json --indent 2
 }
 
 # Delete an application
@@ -146,7 +146,7 @@ export def delete-application [
     $params = ($params | insert propagationPolicy $propagation_policy)
   }
 
-  api-request "delete" $"/api/v1/applications/($name)" $instance --params $params
+  api-request "delete" $"/api/v1/applications/($name)" $instance --params $params | to json --indent 2
 }
 
 # Sync an application
@@ -182,5 +182,5 @@ export def sync-application [
     $params = ($params | insert appNamespace $app_namespace)
   }
 
-  api-request "post" $"/api/v1/applications/($name)/sync" $instance --body $sync_request --params $params
+  api-request "post" $"/api/v1/applications/($name)/sync" $instance --body $sync_request --params $params | to json --indent 2
 }

--- a/tools/argocd/formatters.nu
+++ b/tools/argocd/formatters.nu
@@ -46,11 +46,11 @@ export def get-tool-definitions [] {
         properties: {
           namespace: {
             type: "string"
-            description: "Kubernetes namespace where ArgoCD is installed (e.g., 'argocd'). Used to discover credentials. Optional if server is in cache."
+            description: "Kubernetes namespace for auto-discovery. Server and credentials will be discovered from Kubernetes. Not needed when server is provided."
           }
           server: {
             type: "string"
-            description: "ArgoCD server URL (e.g., 'https://localhost:8080' for port-forward, 'https://argocd.example.com' for LoadBalancer). Optional if using auto-discovery."
+            description: "ArgoCD server URL (e.g., 'https://localhost:8080'). When provided, assumes user has already logged in via 'argocd login' CLI."
           }
           search: {
             type: "string"

--- a/tools/argocd/resources.nu
+++ b/tools/argocd/resources.nu
@@ -25,7 +25,7 @@ export def get-managed-resources [
   }
 
   let response = api-request "get" $"/api/v1/applications/($name)/managed-resources" $instance --params $params
-  {items: ($response.items? | default [])}
+  {items: ($response.items? | default [])} | to json --indent 2
 }
 
 # Get logs for application workload
@@ -62,7 +62,7 @@ export def get-workload-logs [
     $params = ($params | insert tailLines ($tail_lines | into string))
   }
 
-  api-request "get" $"/api/v1/applications/($name)/logs" $instance --params $params
+  api-request "get" $"/api/v1/applications/($name)/logs" $instance --params $params | to json --indent 2
 }
 
 # Get events for specific resource
@@ -87,7 +87,7 @@ export def get-resource-events [
     $params = ($params | insert resourceUID $resource_uid)
   }
 
-  api-request "get" $"/api/v1/applications/($name)/events" $instance --params $params
+  api-request "get" $"/api/v1/applications/($name)/events" $instance --params $params | to json --indent 2
 }
 
 # Get resource manifests
@@ -113,7 +113,7 @@ export def get-resources [
 
     let response = api-request "get" $"/api/v1/applications/($name)/resource" $instance --params $params
     $response.manifest? | default null
-  }
+  } | to json --indent 2
 }
 
 # Get available actions for a resource
@@ -139,7 +139,7 @@ export def get-resource-actions [
   }
 
   let response = api-request "get" $"/api/v1/applications/($name)/resource/actions" $instance --params $params
-  {actions: ($response.actions? | default [])}
+  {actions: ($response.actions? | default [])} | to json --indent 2
 }
 
 # Run a resource action
@@ -166,5 +166,5 @@ export def run-resource-action [
     $params = ($params | insert resourceName $resource_name)
   }
 
-  api-request "post" $"/api/v1/applications/($name)/resource/actions" $instance --body $body --params $params
+  api-request "post" $"/api/v1/applications/($name)/resource/actions" $instance --body $body --params $params | to json --indent 2
 }

--- a/tools/k8s/formatters.nu
+++ b/tools/k8s/formatters.nu
@@ -19,7 +19,7 @@ export def context-parameter [] {
 export def delegate-parameter [] {
   {
     type: "boolean"
-    description: "If true, return the kubectl command string instead of executing it. Useful for delegation to other tools like tmux."
+    description: "If true, return the kubectl command string instead of executing it."
     default: false
   }
 }

--- a/tools/k8s/utils.nu
+++ b/tools/k8s/utils.nu
@@ -353,30 +353,16 @@ export def mask-secrets [data: any] {
   }
 }
 
-# Format MCP tool response
+# Format tool response - just return JSON
+# The Rust MCP server will wrap this in Content::text() automatically
 export def format-tool-response [
   content: any
   --error = false
 ] {
   if $error {
-    {
-      content: [
-        {
-          type: "text"
-          text: ($content | to json --indent 2)
-        }
-      ]
-      isError: true
-    }
+    error make {msg: ($content | to json --indent 2)}
   } else {
-    {
-      content: [
-        {
-          type: "text"
-          text: ($content | to json --indent 2)
-        }
-      ]
-    }
+    $content | to json --indent 2
   }
 }
 

--- a/tools/tmux/process.nu
+++ b/tools/tmux/process.nu
@@ -64,18 +64,16 @@ export def get_pane_process [session: string window?: string pane?: string] {
       $"PID ($pane_pid): ($current_command)"
     }
 
-    [
-      {
-        target: $target
-        pane_index: $pane_index
-        status: $active_status
-        size: $pane_size
-        current_path: $current_path
-        current_command: $current_command
-        process_id: $pane_pid
-        process_details: $process_info
-      }
-    ] | table
+    {
+      target: $target
+      pane_index: $pane_index
+      status: $active_status
+      size: $pane_size
+      current_path: $current_path
+      current_command: $current_command
+      process_id: $pane_pid
+      process_details: $process_info
+    } | to json --indent 2
   } catch {
     $"Error: Failed to get pane process info for '($session)'. Check that the session/pane exists."
   }

--- a/tools/tmux/search.nu
+++ b/tools/tmux/search.nu
@@ -49,7 +49,7 @@ export def find_pane_by_name [session: string pane_name: string] {
     if ($found_panes | length) == 0 {
       $"No pane named '($pane_name)' found in session '($session)'"
     } else {
-      $found_panes | select session window pane title command status path target | table
+      $found_panes | to json --indent 2
     }
   } catch {
     $"Error: Failed to search for pane '($pane_name)' in session '($session)'. Check that the session exists."
@@ -116,7 +116,7 @@ export def find_pane_by_context [session: string context: string] {
     if ($found_panes | length) == 0 {
       $"No pane matching context '($context)' found in session '($session)'"
     } else {
-      $found_panes | select session window pane title command status path target | table
+      $found_panes | to json --indent 2
     }
   } catch {
     $"Error: Failed to search for context '($context)' in session '($session)'. Check that the session exists."

--- a/tools/tmux/session.nu
+++ b/tools/tmux/session.nu
@@ -68,7 +68,7 @@ export def list_sessions [] {
       }
     }
 
-    $all_items | table
+    $all_items | to json --indent 2
   } catch {
     "Error: Failed to list tmux sessions. Make sure tmux is running."
   }
@@ -263,8 +263,8 @@ export def list_panes [session: string] {
       }
     }
 
-    # Create proper nested table structure with expansion
-    $all_panes | select window window_name pane process directory status | group-by window window_name --to-table | update items {|row| $row.items | select pane process directory status } | table --expand
+    # Return panes as JSON
+    $all_panes | to json --indent 2
   } catch {
     $"Error: Failed to list panes for session '($session)'. Check that the session exists."
   }


### PR DESCRIPTION
## Changes

### Critical Bug Fixes
- **K8s tool**: Fixed `format-tool-response` to return plain JSON instead of MCP-wrapped format
  - Tools were returning double-wrapped content that clients couldn't parse
  - Now returns raw JSON that Rust server wraps in MCP Content format

- **ArgoCD tool**: Fixed all functions to return JSON instead of nushell records
  - HTTP responses were being auto-parsed by nushell but not converted back to JSON
  - Added `| to json --indent 2` to all tool functions

- **Tmux tool**: Fixed all functions to return JSON instead of nushell tables
  - Changed `| table` to `| to json --indent 2`

### ArgoCD Improvements
- **2-phased discovery**: 
  - Phase 1: Check namespaces with `app.kubernetes.io/part-of=argocd` label
  - Phase 2: Fallback to common namespace names (`argocd`, `argocd-system`, `argo-cd`)
  
- **Simplified authentication**: When server URL is provided, assumes user already logged in via `argocd login` CLI
  - Skips all Kubernetes discovery
  - Uses existing CLI session
  - Fixed context naming for explicit server URLs

### Documentation
- **tool-development.md**: Added critical section on MCP tool output format
  - Explained that tools must return plain text/JSON
  - Rust server handles MCP Content wrapping
  - Warning about HTTP API responses needing JSON conversion

- **testing.md**: Added requirement to ALWAYS test using `call-tool` function

- **ArgoCD README**: Documented server parameter behavior

## Testing
All tools tested end-to-end using `nu tools/<name>/mod.nu call-tool`:
- ✅ k8s port-forward returns clean JSON
- ✅ ArgoCD with explicit server URL works correctly
- ✅ Tmux returns JSON arrays
- ✅ Finance and c67 tools return plain text (correct)

## Breaking Changes
None - these are bug fixes for MCP protocol compliance