### PR TITLE
feat: externalize run_nushell tool description

### DIFF
--- a/docs/run_nushell_description.txt
+++ b/docs/run_nushell_description.txt
@@ -1,0 +1,9 @@
+Execute Nushell commands and return output.
+
+IMPORTANT:
+- ONLY use Nushell syntax (NOT bash/sh/zsh)
+- If unfamiliar with Nushell, use Context7 to research syntax and commands
+- Commands run in a sandbox directory
+- Use RELATIVE paths only (./file.txt, subdir/file.txt, .)
+- Absolute paths are BLOCKED (e.g., /etc/passwd, /tmp/file)
+- Path traversal (..) is BLOCKED

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -18,6 +18,8 @@ use crate::{
     tools::{NushellToolExecutor, ToolExecutor, discover_tools},
 };
 
+const RUN_NUSHELL_DESCRIPTION: &str = include_str!("../../docs/run_nushell_description.txt");
+
 #[derive(Clone)]
 pub struct NushellTool<C = NushellExecutor, T = NushellToolExecutor>
 where
@@ -102,9 +104,16 @@ where
                 Value::Array(vec![Value::String("command".to_string())]),
             );
 
+            // Build description with sandbox directory info
+            let sandbox_note = match &self.router.config.sandbox_directory {
+                Some(dir) => format!("\n\nSandbox directory: {}", dir.display()),
+                None => "\n\nSandbox directory: current working directory".to_string(),
+            };
+            let description = format!("{}{}", RUN_NUSHELL_DESCRIPTION, sandbox_note);
+
             tools.push(Tool {
                 name: "run_nushell".into(),
-                description: Some("Run a Nushell command and return its output. IMPORTANT: Commands execute in a sandbox directory. Use RELATIVE paths (./file.txt, subdir/file.txt) or current directory (.) - do NOT use absolute paths (/etc/passwd, /tmp/file) as they will be blocked unless within the sandbox. Prefer working with the current directory and relative paths.".into()),
+                description: Some(description.into()),
                 input_schema: Arc::new(schema),
                 annotations: None,
                 title: Some("Run Nushell Command".to_string()),


### PR DESCRIPTION
## Summary
Externalizes the run_nushell tool description to a separate text file for better maintainability and clarity.

## Changes
- Created docs/run_nushell_description.txt with succinct, clear description
- Modified src/mcp/mod.rs to load description at compile time using include_str! macro
- Added runtime sandbox directory info appended to the static description
- Emphasized Nushell-only syntax requirement
- Added instruction to use Context7 for Nushell research when unfamiliar

## Benefits
- Better readability: Description is easier to read and edit in a text file
- Easier maintenance: Can update instructions without touching Rust code
- Separation of concerns: Content separated from code logic
- More succinct: Reduced verbosity while maintaining clarity
- Better guidance: Explicit instruction to research with Context7

## Testing
- Compiled successfully with cargo build --release
- Description file loaded correctly at compile time
- Sandbox directory properly appended at runtime