### PR TITLE
feat: support multiple sandbox directories for command execution

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,8 +11,8 @@ The `nu-mcp` server is configured via command-line arguments or by passing argum
   Explicitly re-enable the `run_nushell` tool when using `--tools-dir`. This creates a hybrid mode where both extension tools and generic nushell command execution are available. Use with caution in multi-instance setups to avoid tool name conflicts.
 
 ### Security Options
-- `--sandbox-dir=PATH`
-  Directory to sandbox nushell execution (default: current working directory). Commands are restricted to this directory and cannot access parent directories or absolute paths outside the sandbox.
+- `--sandbox-dir=PATH` (can be specified multiple times)
+  Directories where commands can access files. Commands are restricted to these directories and cannot access files outside them. If not specified, defaults to current working directory. All sandbox directories are equal - there is no "primary" vs "additional" distinction.
 
 ## Example Configurations
 
@@ -42,3 +42,19 @@ nu-mcp-hybrid:
     - "--enable-run-nushell"
     - "--sandbox-dir=/safe/workspace"
 ```
+
+### With Multiple Sandboxes
+```yaml
+nu-mcp-multi-sandbox:
+  command: "nu-mcp"
+  args:
+    - "--sandbox-dir=/workspace"
+    - "--sandbox-dir=/tmp"
+    - "--sandbox-dir=/var/log"
+    - "--sandbox-dir=/home/user/projects"
+```
+
+This configuration allows commands to access:
+- All specified sandbox directories: `/workspace`, `/tmp`, `/var/log`, `/home/user/projects`
+- Any subdirectories within these sandboxes
+- Working directory: Current directory if within a sandbox, otherwise first sandbox

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,11 +1,44 @@
 # Security
 
 ## Sandbox Security
-- Commands execute within a directory sandbox (configurable with `--sandbox-dir`)
-- Path traversal is context-aware: `../` is allowed if it stays within the sandbox
-- Absolute paths outside the sandbox directory are blocked
+- Commands execute within sandbox directories (configurable with `--sandbox-dir`)
+- Multiple sandbox directories can be specified (all equal, no hierarchy)
+- Path traversal is context-aware: `../` is allowed if it stays within sandbox directories
+- Absolute paths outside sandbox directories are blocked
+- If no `--sandbox-dir` specified, defaults to current working directory
 - Extensions run in the same security context as the server process
 - The sandbox provides directory isolation but does not restrict system resources, network access, or process spawning
+
+## Multiple Sandbox Directories
+
+The `--sandbox-dir` option can be specified multiple times to allow access to multiple directories. This is useful for:
+- Accessing temporary directories (e.g., `/tmp`)
+- Reading log files (e.g., `/var/log`)
+- Working with multiple project directories
+- Granting controlled access to specific system directories
+
+**Example:**
+```bash
+nu-mcp --sandbox-dir=/workspace \
+       --sandbox-dir=/tmp \
+       --sandbox-dir=/var/log \
+       --sandbox-dir=/home/user/projects
+```
+
+With this configuration:
+- ✅ Allowed: `/workspace/file.txt`, `/tmp/cache.db`, `/var/log/app.log`, `/home/user/projects/code.rs`
+- ❌ Blocked: `/etc/passwd`, `/root/secret`, `/home/other-user/data`
+
+**Working Directory:**
+- Commands execute from current directory if it's within any sandbox
+- Otherwise, commands execute from the first sandbox directory
+
+**Security Notes:**
+- Sandbox directories are canonicalized (symlinks resolved) before validation
+- Non-existent sandbox directories are ignored (they won't cause errors but won't grant access)
+- Path traversal (`../`) is validated after resolution - escaping sandboxes is blocked
+- Subdirectories within sandbox directories are automatically allowed
+- All sandbox directories are equal - there is no "primary" or "special" sandbox
 
 ## Safe Command Whitelist
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -12,9 +12,10 @@ pub struct Cli {
     #[arg(long, default_value_t = false)]
     pub enable_run_nushell: bool,
 
-    /// Directory to sandbox nushell execution (default: current working directory)
-    #[arg(long)]
-    pub sandbox_dir: Option<PathBuf>,
+    /// Directories where commands can access files (can be specified multiple times)
+    /// If not specified, defaults to current working directory
+    #[arg(long = "sandbox-dir")]
+    pub sandbox_dirs: Vec<PathBuf>,
 }
 
 #[cfg(test)]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 pub struct Config {
     pub tools_dir: Option<PathBuf>,
     pub enable_run_nushell: bool,
-    pub sandbox_directory: Option<PathBuf>,
+    pub sandbox_directories: Vec<PathBuf>,
 }
 
 #[cfg(test)]

--- a/src/config/mod_test.rs
+++ b/src/config/mod_test.rs
@@ -8,12 +8,12 @@ fn test_config_creation_default() {
     let config = Config {
         tools_dir: None,
         enable_run_nushell: false,
-        sandbox_directory: None,
+        sandbox_directories: vec![],
     };
 
     assert!(config.tools_dir.is_none());
     assert!(!config.enable_run_nushell);
-    assert!(config.sandbox_directory.is_none());
+    assert!(config.sandbox_directories.is_empty());
 }
 
 #[test]
@@ -23,7 +23,7 @@ fn test_config_creation_tools_dir() {
     let config = Config {
         tools_dir: Some(tools_path.clone()),
         enable_run_nushell: false,
-        sandbox_directory: None,
+        sandbox_directories: vec![],
     };
 
     assert_eq!(config.tools_dir, Some(tools_path));
@@ -34,37 +34,38 @@ fn test_config_creation_enable_run_nushell() {
     let config = Config {
         tools_dir: None,
         enable_run_nushell: true,
-        sandbox_directory: None,
+        sandbox_directories: vec![],
     };
 
     assert!(config.enable_run_nushell);
 }
 
 #[test]
-fn test_config_creation_sandbox_directory() {
+fn test_config_creation_sandbox_directories() {
     let sandbox_path = PathBuf::from("/tmp/sandbox");
 
     let config = Config {
         tools_dir: None,
         enable_run_nushell: false,
-        sandbox_directory: Some(sandbox_path.clone()),
+        sandbox_directories: vec![sandbox_path.clone()],
     };
 
-    assert_eq!(config.sandbox_directory, Some(sandbox_path));
+    assert_eq!(config.sandbox_directories, vec![sandbox_path]);
 }
 
 #[test]
 fn test_config_creation_full_configuration() {
     let tools_path = PathBuf::from("/custom/tools");
-    let sandbox_path = PathBuf::from("/custom/jail");
+    let sandbox1 = PathBuf::from("/custom/sandbox1");
+    let sandbox2 = PathBuf::from("/custom/sandbox2");
 
     let config = Config {
         tools_dir: Some(tools_path.clone()),
         enable_run_nushell: true,
-        sandbox_directory: Some(sandbox_path.clone()),
+        sandbox_directories: vec![sandbox1.clone(), sandbox2.clone()],
     };
 
     assert_eq!(config.tools_dir, Some(tools_path));
     assert!(config.enable_run_nushell);
-    assert_eq!(config.sandbox_directory, Some(sandbox_path));
+    assert_eq!(config.sandbox_directories, vec![sandbox1, sandbox2]);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,23 @@
 use anyhow::Result;
 use clap::Parser;
 use nu_mcp::{cli::Cli, config::Config, mcp::run_server};
+use std::env;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
 
+    // Default to current directory if no sandboxes specified
+    let sandbox_directories = if cli.sandbox_dirs.is_empty() {
+        vec![env::current_dir()?]
+    } else {
+        cli.sandbox_dirs
+    };
+
     let config = Config {
         tools_dir: cli.tools_dir,
         enable_run_nushell: cli.enable_run_nushell,
-        sandbox_directory: cli.sandbox_dir,
+        sandbox_directories,
     };
 
     run_server(config).await

--- a/src/mcp/mod_test.rs
+++ b/src/mcp/mod_test.rs
@@ -10,7 +10,7 @@ fn test_get_info_includes_sandbox_info() {
     let config = Config {
         tools_dir: None,
         enable_run_nushell: false,
-        sandbox_directory: Some(PathBuf::from("/tmp/sandbox")),
+        sandbox_directories: vec![PathBuf::from("/tmp/sandbox")],
     };
     let executor = MockExecutor::new("test".to_string(), "".to_string());
     let tool_executor = MockToolExecutor::new("test".to_string());
@@ -18,7 +18,7 @@ fn test_get_info_includes_sandbox_info() {
     let tool = NushellTool { router };
     let info = tool.get_info();
     let instructions = info.instructions.unwrap();
-    assert!(instructions.contains("directory sandbox"));
+    assert!(instructions.contains("Sandbox directories"));
     assert!(instructions.contains("/tmp/sandbox"));
 }
 
@@ -27,7 +27,7 @@ fn test_get_info_default_sandbox() {
     let config = Config {
         tools_dir: None,
         enable_run_nushell: false,
-        sandbox_directory: None,
+        sandbox_directories: vec![],
     };
     let executor = MockExecutor::new("test".to_string(), "".to_string());
     let tool_executor = MockToolExecutor::new("test".to_string());
@@ -43,7 +43,7 @@ fn test_get_info_basic_fields() {
     let config = Config {
         tools_dir: None,
         enable_run_nushell: false,
-        sandbox_directory: None,
+        sandbox_directories: vec![],
     };
     let executor = MockExecutor::new("test".to_string(), "".to_string());
     let tool_executor = MockToolExecutor::new("test".to_string());

--- a/src/mcp/router_test.rs
+++ b/src/mcp/router_test.rs
@@ -16,7 +16,7 @@ fn create_test_router() -> ToolRouter<MockExecutor, MockToolExecutor> {
     let config = Config {
         tools_dir: None,
         enable_run_nushell: true,
-        sandbox_directory: Some(PathBuf::from("/tmp")),
+        sandbox_directories: vec![PathBuf::from("/tmp")],
     };
     let executor = MockExecutor::new("test output".to_string(), "".to_string());
     let tool_executor = MockToolExecutor::new("tool output".to_string());
@@ -66,7 +66,7 @@ async fn test_router_extension_tool() {
     let config = Config {
         tools_dir: None,
         enable_run_nushell: true,
-        sandbox_directory: Some(PathBuf::from("/tmp")),
+        sandbox_directories: vec![PathBuf::from("/tmp")],
     };
 
     let extension = ExtensionTool {


### PR DESCRIPTION
Adds support for specifying multiple sandbox directories for command execution, enhancing security and flexibility.

- Updates CLI, config, and server logic to accept multiple --sandbox-dir arguments
- Refactors path validation to check all configured sandboxes, not just one
- Updates documentation to describe multi-sandbox usage and security implications
- Adjusts tests and error messages for multi-sandbox scenarios
- Ensures commands execute from current directory if within any sandbox, otherwise from the first sandbox directory