### PR TITLE
fix(c5t): correct schema types for list_id, item_id, and note_id to integer

### DIFF
--- a/tools/c5t/mod.nu
+++ b/tools/c5t/mod.nu
@@ -57,7 +57,7 @@ def "main list-tools" [] {
         type: "object"
         properties: {
           list_id: {
-            type: "string"
+            type: "integer"
             description: "ID of the todo list to add the item to"
           }
           content: {
@@ -86,11 +86,11 @@ def "main list-tools" [] {
         type: "object"
         properties: {
           list_id: {
-            type: "string"
+            type: "integer"
             description: "ID of the todo list containing the item"
           }
           item_id: {
-            type: "string"
+            type: "integer"
             description: "ID of the item to update"
           }
           status: {
@@ -109,11 +109,11 @@ def "main list-tools" [] {
         type: "object"
         properties: {
           list_id: {
-            type: "string"
+            type: "integer"
             description: "ID of the todo list containing the item"
           }
           item_id: {
-            type: "string"
+            type: "integer"
             description: "ID of the item to update"
           }
           priority: {
@@ -133,11 +133,11 @@ def "main list-tools" [] {
         type: "object"
         properties: {
           list_id: {
-            type: "string"
+            type: "integer"
             description: "ID of the todo list containing the item"
           }
           item_id: {
-            type: "string"
+            type: "integer"
             description: "ID of the item to complete"
           }
         }
@@ -151,7 +151,7 @@ def "main list-tools" [] {
         type: "object"
         properties: {
           list_id: {
-            type: "string"
+            type: "integer"
             description: "ID of the todo list"
           }
           status: {
@@ -170,7 +170,7 @@ def "main list-tools" [] {
         type: "object"
         properties: {
           list_id: {
-            type: "string"
+            type: "integer"
             description: "ID of the todo list"
           }
         }
@@ -184,7 +184,7 @@ def "main list-tools" [] {
         type: "object"
         properties: {
           list_id: {
-            type: "string"
+            type: "integer"
             description: "ID of the todo list to update"
           }
           notes: {
@@ -249,7 +249,7 @@ def "main list-tools" [] {
         type: "object"
         properties: {
           note_id: {
-            type: "string"
+            type: "integer"
             description: "ID of the note to retrieve"
           }
         }

--- a/tools/c5t/tests/test_mod.nu
+++ b/tools/c5t/tests/test_mod.nu
@@ -120,3 +120,49 @@ main call-tool 'c5t_create_list' '{\"name\": \"\"}'
   # Should return error message about empty name
   assert ($output | str contains "cannot be empty")
 }
+
+# Test schema types match function signatures for ID parameters
+export def "test schema types match function signatures" [] {
+  let test_script = "
+source tools/c5t/mod.nu
+main list-tools
+"
+
+  let output = nu -c $test_script
+  let tools = $output | from json
+
+  # Check c5t_add_item has integer list_id
+  let add_item = $tools | where name == "c5t_add_item" | first
+  assert ($add_item.input_schema.properties.list_id.type == "integer")
+
+  # Check c5t_update_item_status has integer list_id and item_id
+  let update_status = $tools | where name == "c5t_update_item_status" | first
+  assert ($update_status.input_schema.properties.list_id.type == "integer")
+  assert ($update_status.input_schema.properties.item_id.type == "integer")
+
+  # Check c5t_update_item_priority has integer list_id and item_id
+  let update_priority = $tools | where name == "c5t_update_item_priority" | first
+  assert ($update_priority.input_schema.properties.list_id.type == "integer")
+  assert ($update_priority.input_schema.properties.item_id.type == "integer")
+
+  # Check c5t_complete_item has integer list_id and item_id
+  let complete_item = $tools | where name == "c5t_complete_item" | first
+  assert ($complete_item.input_schema.properties.list_id.type == "integer")
+  assert ($complete_item.input_schema.properties.item_id.type == "integer")
+
+  # Check c5t_list_items has integer list_id
+  let list_items = $tools | where name == "c5t_list_items" | first
+  assert ($list_items.input_schema.properties.list_id.type == "integer")
+
+  # Check c5t_list_active_items has integer list_id
+  let list_active_items = $tools | where name == "c5t_list_active_items" | first
+  assert ($list_active_items.input_schema.properties.list_id.type == "integer")
+
+  # Check c5t_update_notes has integer list_id
+  let update_notes = $tools | where name == "c5t_update_notes" | first
+  assert ($update_notes.input_schema.properties.list_id.type == "integer")
+
+  # Check c5t_get_note has integer note_id
+  let get_note = $tools | where name == "c5t_get_note" | first
+  assert ($get_note.input_schema.properties.note_id.type == "integer")
+}


### PR DESCRIPTION
## Problem

All c5t item operations failed when called via MCP with error:
```
Error: nu::shell::cant_convert
  x Can't convert to int.
```

## Root Cause

Schema type mismatch:
- **Schemas** declared `list_id`, `item_id`, `note_id` as `type: "string"`
- **Functions** expected `list_id: int`, `item_id: int`, `note_id: int`

When called via MCP, JSON passes `"2"` (string), but functions expect `2` (int).

## Why This Slipped Through

1. **Unit tests** used mocks - didn't enforce type constraints
2. **Manual testing** used direct Nushell calls - auto-coerces types
3. **MCP usage** passes JSON - no auto-coercion, strict types

## Solution

Changed schema types from `string` to `integer` for:
- `list_id` in 7 tools (add_item, update_item_status, update_item_priority, complete_item, list_items, list_active_items, update_notes)
- `item_id` in 4 tools (update_item_status, update_item_priority, complete_item)
- `note_id` in 1 tool (get_note)

## Testing

Added new test: `test schema types match function signatures`
- Validates all ID parameters in schemas match expected types
- **Results: 86/86 tests passing** (was 85, added 1 new test)

## TDD Workflow Used

1. ✅ Wrote failing test first (caught the bug)
2. ✅ Fixed code to make test pass
3. ✅ Verified all tests pass

This test will prevent similar type mismatches in the future.

## Affected Tools

All c5t item management tools now work correctly via MCP:
- c5t_add_item
- c5t_update_item_status
- c5t_update_item_priority
- c5t_complete_item
- c5t_list_items
- c5t_list_active_items
- c5t_update_notes
- c5t_get_note
