### PR TITLE
fix(c5t): use path self for SQL migration files location

### DIFF
--- a/tools/c5t/storage.nu
+++ b/tools/c5t/storage.nu
@@ -32,9 +32,10 @@ export def run-migrations [] {
   $db_path
 }
 
+const SQL_DIR = (path self sql)
+
 def get-migration-files [] {
-  let sql_dir = "tools/c5t/sql"
-  glob $"($sql_dir)/*.sql" | sort
+  glob $"($SQL_DIR)/*.sql" | sort
 }
 
 def get-migration-version [filepath: string] {


### PR DESCRIPTION
## Problem

Database migrations only worked when running from the repo root because `get-migration-files` used a hardcoded relative path `tools/c5t/sql`.

When MCP runs from a different project directory, it couldn't find the SQL files.

## Solution

Use Nushell's `path self` command to get the directory of the current script at parse time:

```nushell
const SQL_DIR = (path self sql)
```

This resolves the path relative to where `storage.nu` is located, not the current working directory.

## Testing

- All 47 tests pass
- Migrations now work regardless of CWD
