### PR TITLE
docs(c5t): update README and implementation plan

### DIFF
--- a/docs/implementation-plans/c5t-implementation-plan.md
+++ b/docs/implementation-plans/c5t-implementation-plan.md
@@ -2,9 +2,10 @@
 
 ## Overview
 
-- **Purpose**: Context/memory management tool to preserve context across sessions, track work via todo lists, and store knowledge in notes. Addresses context loss in LLM continuation summaries.
+- **Purpose**: Context/memory management tool to preserve context across sessions, track work via task lists, and store knowledge in notes. Addresses context loss in LLM continuation summaries.
 - **Target Users**: Developers working on projects with nu-mcp, especially across multiple sessions
 - **External Dependencies**: SQLite (via Nushell's built-in `query db` command)
+- **Status**: **COMPLETE** - All milestones implemented and tested
 
 ## Problem Statement
 
@@ -18,1080 +19,220 @@ This causes developers to re-search for files, re-explain context, and lose mome
 
 ## Goals
 
-1. **Todo List Management**: Track work items and progress
-2. **Auto-Archive**: Completed todo lists automatically become notes
+1. **Task List Management**: Track work items and progress with Kanban-style statuses
+2. **Subtasks**: Break down complex tasks into smaller pieces
 3. **Markdown Notes**: Store knowledge with rich formatting
-4. **Scratchpad**: Auto-update context snapshot every 25% token usage
-5. **Search**: Find past decisions and knowledge
-6. **Per-Project Storage**: Each project has its own `.c5t/context.db`
+4. **Search**: Find past decisions and knowledge via FTS5
+5. **Per-Project Storage**: Each repository has isolated data via git remote URL
+6. **Export/Import**: Backup and restore all data
 
-## Capabilities
+## Capabilities (All Implemented)
 
-- [ ] Create todo lists with items
-- [ ] Mark items complete, auto-archive when all done
-- [ ] Update progress notes on todo lists (markdown)
-- [ ] Create standalone notes (markdown)
-- [ ] Search notes by tags and full-text
-- [ ] Scratchpad for session context preservation
-- [ ] List active todos and archived notes
+- [x] Create task lists with tasks
+- [x] Subtasks with parent_id reference
+- [x] Update progress notes on task lists (markdown)
+- [x] Create standalone notes (markdown)
+- [x] Search notes by tags and full-text (FTS5)
+- [x] List active task lists and notes
+- [x] Export/import data for backup/restore
+- [x] Project isolation via git remote URL
 
 ## Module Structure
 
-- `mod.nu`: MCP interface and tool routing
+- `mod.nu`: MCP interface and tool routing (20 tools)
 - `storage.nu`: SQLite database operations (CRUD)
-- `formatters.nu`: Output formatting for MCP responses
-- `utils.nu`: ID generation, validation, helpers
+- `formatters.nu`: Output formatting using Nushell tables
+- `utils.nu`: Validation and helper functions
+- `sql/0001_initial_schema.sql`: Database schema
 - `README.md`: User documentation
 
 ## Database Schema
 
-### Design Philosophy: Kanban-Ready
-
-The schema supports Kanban-style workflow with multiple item statuses. The MVP will implement basic statuses (todo, in_progress, done), but the schema is designed to support full Kanban visualization in future iterations.
-
-**Todo Item Statuses:**
-- `backlog`: Planned but not prioritized (future)
-- `todo`: Ready to work on (MVP)
-- `in_progress`: Currently being worked on (MVP)
-- `review`: Awaiting review/validation (future)
-- `done`: Completed successfully (MVP)
-- `cancelled`: No longer needed (MVP)
-
-**Future Enhancements:**
-- Visual Kanban board rendering (columns view)
-- `c5t_move_item` tool to transition between statuses
-- `c5t_get_board` tool to visualize items grouped by status
-- Position/ordering within status columns
-- WIP (Work In Progress) limits per status
-
-### Tables
+### Current Schema (v1)
 
 ```sql
--- Todo List
-CREATE TABLE IF NOT EXISTS todo_list (
-    id TEXT PRIMARY KEY,
+-- Repository tracking for project isolation
+CREATE TABLE IF NOT EXISTS repo (
+    id INTEGER PRIMARY KEY,
+    remote TEXT NOT NULL UNIQUE,
+    path TEXT,
+    created_at TEXT DEFAULT (datetime('now')),
+    last_accessed TEXT DEFAULT (datetime('now'))
+);
+
+-- Task List
+CREATE TABLE IF NOT EXISTS task_list (
+    id INTEGER PRIMARY KEY,
+    repo_id INTEGER NOT NULL,
     name TEXT NOT NULL,
     description TEXT,
-    notes TEXT,                    -- Progress notes (markdown)
-    tags TEXT,                     -- JSON array: ["tag1", "tag2"]
-    status TEXT DEFAULT 'active' CHECK(status IN ('active', 'archived')),
+    notes TEXT,
+    tags TEXT,  -- JSON array
     created_at TEXT DEFAULT (datetime('now')),
     updated_at TEXT DEFAULT (datetime('now')),
-    archived_at TEXT
+    FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE
 );
 
--- Todo Item
-CREATE TABLE IF NOT EXISTS todo_item (
-    id TEXT PRIMARY KEY,
-    list_id TEXT NOT NULL,
+-- Task (supports subtasks via parent_id)
+CREATE TABLE IF NOT EXISTS task (
+    id INTEGER PRIMARY KEY,
+    list_id INTEGER NOT NULL,
+    parent_id INTEGER,  -- Self-referential FK for subtasks
     content TEXT NOT NULL,
-    status TEXT DEFAULT 'todo' CHECK(status IN ('backlog', 'todo', 'in_progress', 'review', 'done', 'cancelled')),
-    position INTEGER DEFAULT 0,   -- Order within status column (for future Kanban view)
+    status TEXT DEFAULT 'backlog' CHECK(status IN ('backlog', 'todo', 'in_progress', 'review', 'done', 'cancelled')),
+    priority INTEGER CHECK(priority IS NULL OR (priority >= 1 AND priority <= 5)),
     created_at TEXT DEFAULT (datetime('now')),
-    started_at TEXT,              -- When moved to in_progress
-    completed_at TEXT,            -- When moved to done
-    FOREIGN KEY (list_id) REFERENCES todo_list(id) ON DELETE CASCADE
+    started_at TEXT,
+    completed_at TEXT,
+    FOREIGN KEY (list_id) REFERENCES task_list(id) ON DELETE CASCADE,
+    FOREIGN KEY (parent_id) REFERENCES task(id) ON DELETE CASCADE
 );
 
--- Note (archived todos + standalone notes + scratchpad)
+-- Note
 CREATE TABLE IF NOT EXISTS note (
-    id TEXT PRIMARY KEY,
+    id INTEGER PRIMARY KEY,
+    repo_id INTEGER NOT NULL,
     title TEXT NOT NULL,
-    content TEXT NOT NULL,         -- Markdown content
-    tags TEXT,                     -- JSON array
-    note_type TEXT DEFAULT 'manual' CHECK(note_type IN ('manual', 'archived_todo', 'scratchpad')),
-    source_id TEXT,                -- Original todo list ID if archived
+    content TEXT NOT NULL,
+    tags TEXT,  -- JSON array
+    note_type TEXT DEFAULT 'manual' CHECK(note_type IN ('manual', 'archived_todo')),
     created_at TEXT DEFAULT (datetime('now')),
-    updated_at TEXT DEFAULT (datetime('now'))
+    updated_at TEXT DEFAULT (datetime('now')),
+    FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE
 );
-
--- Indexes
-CREATE INDEX IF NOT EXISTS idx_todo_list_status ON todo_list(status);
-CREATE INDEX IF NOT EXISTS idx_todo_item_list ON todo_item(list_id);
-CREATE INDEX IF NOT EXISTS idx_todo_item_status ON todo_item(status);  -- For Kanban queries
-CREATE INDEX IF NOT EXISTS idx_todo_item_list_status ON todo_item(list_id, status);  -- Combined for filtering
-CREATE INDEX IF NOT EXISTS idx_note_type ON note(note_type);
 
 -- Full-text search
 CREATE VIRTUAL TABLE IF NOT EXISTS note_fts USING fts5(
-    title,
-    content,
-    content=note,
-    content_rowid=id
+    title, content, content=note, content_rowid=id
 );
-
--- FTS sync triggers
-CREATE TRIGGER IF NOT EXISTS note_ai AFTER INSERT ON note BEGIN
-    INSERT INTO note_fts(rowid, title, content) 
-    VALUES (new.id, new.title, new.content);
-END;
-
-CREATE TRIGGER IF NOT EXISTS note_au AFTER UPDATE ON note BEGIN
-    UPDATE note_fts SET title = new.title, content = new.content 
-    WHERE rowid = new.id;
-END;
-
-CREATE TRIGGER IF NOT EXISTS note_ad AFTER DELETE ON note BEGIN
-    DELETE FROM note_fts WHERE rowid = old.id;
-END;
-
--- Auto-update timestamps
-CREATE TRIGGER IF NOT EXISTS todo_list_update AFTER UPDATE ON todo_list BEGIN
-    UPDATE todo_list SET updated_at = datetime('now') WHERE id = NEW.id;
-END;
-
-CREATE TRIGGER IF NOT EXISTS note_update AFTER UPDATE ON note BEGIN
-    UPDATE note SET updated_at = datetime('now') WHERE id = NEW.id;
-END;
 ```
 
-## Context7 Research
+### Key Design Decisions
 
-- [x] Research Nushell SQLite integration (built-in `query db`)
-- [x] Research markdown handling in Nushell
-- [ ] Research existing note-taking tool patterns (Obsidian, Notion)
+- **INTEGER PRIMARY KEYs**: Auto-incrementing IDs for simplicity
+- **repo_id foreign key**: All task_lists and notes belong to a repository
+- **parent_id for subtasks**: Self-referential FK with CASCADE delete
+- **No position column**: Removed as unnecessary complexity
+- **No scratchpad**: Session notes pattern with tags replaces dedicated scratchpad
+- **No auto-archive**: Removed as it added complexity without clear benefit
 
-## Security Considerations
+## Available Tools (20 Total)
 
-- **No safety modes needed**: This tool manages local project data only
-- **No sensitive data**: All data is project-specific context
-- **File permissions**: Database stored in `.c5t/` (can be gitignored)
+### Repository Management
+| Tool | Description |
+|------|-------------|
+| `upsert_repo` | Register or update a git repository |
+| `list_repos` | List all known repositories |
 
-## Implementation Milestones
+### Task Lists
+| Tool | Description |
+|------|-------------|
+| `upsert_task_list` | Create or update a task list |
+| `list_task_lists` | List task lists with status counts |
+| `get_task_list` | Get list metadata |
+| `delete_task_list` | Remove a list (force=true if has tasks) |
 
-### Milestone 1: Basic Structure & Database
-**Goal**: Set up tool skeleton and SQLite database initialization
+### Tasks
+| Tool | Description |
+|------|-------------|
+| `upsert_task` | Create or update a task (supports parent_id for subtasks) |
+| `list_tasks` | View tasks, filter by status array or parent_id |
+| `complete_task` | Mark task as done |
+| `delete_task` | Remove a task |
+| `move_task` | Move task to another list |
 
-**Tasks**:
-- [ ] Create `tools/c5t/` directory structure
-- [ ] Create `mod.nu` skeleton with `list-tools` and `call-tool`
-- [ ] Create `storage.nu` with database initialization
-- [ ] Implement schema creation (SQL above)
-- [ ] Create `utils.nu` with ID generation
-- [ ] Create `formatters.nu` stub
-- [ ] Test database creation
+### Notes
+| Tool | Description |
+|------|-------------|
+| `upsert_note` | Create or update a note |
+| `list_notes` | List notes with optional filters |
+| `get_note` | Get specific note by ID |
+| `delete_note` | Remove a note |
+| `search` | FTS5 full-text search |
 
-**Validation**:
+### Summary & Data
+| Tool | Description |
+|------|-------------|
+| `get_summary` | Quick status overview with recent completions |
+| `export_data` | Export all data to JSON backup |
+| `import_data` | Import data from backup (replaces existing) |
+| `list_backups` | List available backup files |
+
+## Output Formatting
+
+All table outputs use Nushell's native table rendering:
+- Box-drawing characters for borders
+- Word wrapping after 10 words for long content
+- Status emojis: `backlog`, `todo`, `in_progress`, `review`, `done`, `cancelled`
+- Compact task table columns: ID, P (priority), Content, S (status emoji)
+- Tool descriptions instruct LLM to display output directly
+
+## Implementation Status
+
+All milestones complete:
+
+| Milestone | Description | Status |
+|-----------|-------------|--------|
+| 1 | Basic Structure & Database | COMPLETE |
+| 2 | Task List Creation | COMPLETE |
+| 3 | Tasks Management | COMPLETE |
+| 4 | Progress Notes | COMPLETE |
+| 5 | Subtasks | COMPLETE |
+| 6 | Standalone Notes | COMPLETE |
+| 7 | Full-Text Search | COMPLETE |
+| 8 | Export/Import | COMPLETE |
+| 9 | Formatters & Output | COMPLETE |
+| 10 | Error Handling | COMPLETE |
+| 11 | Documentation | COMPLETE |
+| 12 | Testing | COMPLETE (52 tests) |
+
+## Testing
+
+- **52 unit/integration tests** in `tests/` directory
+- Test files:
+  - `test_mod.nu` - Tool schema and routing tests
+  - `test_formatters.nu` - Output formatting tests
+  - `test_utils.nu` - Validation function tests
+  - `test_subtasks.nu` - Subtask functionality tests
+  - `test_task_schema.nu` - Database schema tests
+  - `test_helpers.nu` - Test utilities
+
+Run tests:
 ```bash
-nu tools/c5t/mod.nu list-tools | from json
-# Should return empty array
-
-ls .c5t/context.db
-# Database file should exist with correct schema
+nu tools/c5t/tests/run_tests.nu
 ```
 
-**Acceptance Criteria**:
-- [ ] Tool discovered by nu-mcp
-- [ ] Database created in `.c5t/context.db`
-- [ ] Schema created successfully
-- [ ] All tables and triggers exist
-
----
-
-### Milestone 2: Todo List Creation
-**Goal**: Create and list todo lists
-
-**Tools to Implement**:
-- `c5t_create_list` - Create new todo list
-- `c5t_list_active` - Show all active todo lists
-
-**Functions** (storage.nu, kebab-case):
-- `init-database` - Ensure DB and schema exist
-- `create-todo-list [name, description, tags]`
-- `get-active-lists [tag_filter?]`
-- `generate-id` - Unique ID generation
-
-**Validation**:
-```bash
-nu tools/c5t/mod.nu call-tool c5t_create_list '{
-  "name": "Test Feature",
-  "description": "Testing c5t",
-  "tags": ["test"]
-}'
-
-nu tools/c5t/mod.nu call-tool c5t_list_active '{}'
-# Should show the created list
-```
-
-**Acceptance Criteria**:
-- [x] Can create todo list with name, description, tags
-- [x] List shows active todo lists
-- [x] Tags stored as JSON array
-- [x] Created_at timestamp set automatically
-- [x] Status defaults to 'active'
-- [x] SOLID principles applied (execute-sql, query-sql abstractions)
-- [x] All tests passing (41/41)
-
-**Status**: ✅ COMPLETE (commit 19f3b8f)
-
----
-
-### Milestone 3: Todo Items Management
-**Goal**: Add and manage todo items with status transitions
-
-**Tools Implemented**:
-- `c5t_add_item` - Add item to list (defaults to 'backlog' status)
-- `c5t_update_item_status` - Change item status with automatic timestamp management
-- `c5t_update_item_priority` - Update item priority (1-5 scale)
-- `c5t_complete_item` - Shortcut to mark item as 'done'
-- `c5t_list_items` - List items with optional status filter
-- `c5t_list_active_items` - List only active items (excludes done/cancelled)
-
-**Functions Implemented** (storage.nu, kebab-case):
-- `add-todo-item [list_id, content, priority?, status?]` - Status defaults to 'backlog', priority optional (1-5)
-- `update-item-status [list_id, item_id, new_status]` - Automatic timestamp management (started_at, completed_at)
-- `update-item-priority [list_id, item_id, priority]` - Update priority (1-5 or null)
-- `get-list-with-items [list_id, status_filter?]` - Get list with items, optional filter ('active', or specific status)
-- `get-item [list_id, item_id]` - Get single item
-- `list-exists [list_id]` - Check if list exists
-- `item-exists [list_id, item_id]` - Check if item exists
-
-**Validation Functions** (utils.nu):
-- `validate-status [status]` - Validates against allowed statuses
-- `validate-priority [priority]` - Validates 1-5 range
-- `validate-item-update-input [args]` - Validates list_id and item_id fields
-
-**Timestamp Automation**:
-- Moving to `in_progress`: Sets `started_at` if null
-- Moving to `done` or `cancelled`: Sets `completed_at`
-- Moving from `done`/`cancelled` to `backlog`/`todo`: Clears both timestamps
-- Moving from `in_progress` to `backlog`/`todo`: Clears `started_at`
-
-**Status Transitions**:
-- Flexible (any-to-any) - no strict validation
-- Supports: `backlog`, `todo`, `in_progress`, `review`, `done`, `cancelled`
-
-**Acceptance Criteria**:
-- [x] Can add items to existing list (default status: 'backlog')
-- [x] Can update item status (flexible transitions)
-- [x] Can update item priority (1-5 scale, nullable)
-- [x] Can mark items complete with shortcut
-- [x] completed_at timestamp set when status becomes 'done' or 'cancelled'
-- [x] started_at timestamp set when status becomes 'in_progress'
-- [x] Timestamps cleared when moving back to backlog/todo
-- [x] List shows items grouped by status with priority ordering
-- [x] Can filter items by status or show only active items
-- [x] All validation working (status, priority, existence checks)
-- [x] 58 tests passing (43 original + 15 new tests)
-
-**Status**: ✅ COMPLETE (commit pending)
-
----
-
-### Milestone 4: Progress Notes on Todo Lists
-**Goal**: Update progress notes on todo lists
-
-**Tools Implemented**:
-- `c5t_update_notes` - Update notes field on list (supports markdown)
-
-**Functions Implemented** (storage.nu, kebab-case):
-- `update-todo-notes [list_id, notes]` - Update notes field with SQL escaping
-
-**Formatter Added**:
-- `format-notes-updated [list_id]` - Confirmation message for notes update
-
-**Modified Functions**:
-- `get-active-lists` - Now includes notes field in SELECT query
-- `format-active-lists` - Displays notes if present
-
-**Validation**:
-```bash
-nu tools/c5t/mod.nu call-tool c5t_update_notes '{
-  "list_id": "...",
-  "notes": "## Progress\n\nCompleted schema, working on CRUD operations"
-}'
-```
-
-**Acceptance Criteria**:
-- [x] Can update notes field with markdown
-- [x] Notes preserved as-is (no markdown rendering)
-- [x] Updated_at timestamp changes automatically (database trigger)
-- [x] Notes visible in list_active output
-- [x] 61 tests passing (58 from M3 + 3 new tests)
-
-**Status**: ✅ COMPLETE (commit pending)
-
----
-
-### Milestone 5: Auto-Archive Logic
-**Goal**: Automatically archive completed todo lists as notes
-
-**Functions Implemented** (storage.nu, kebab-case):
-- `generate-archive-note [todo_list, items]` - Creates formatted markdown from list and items
-- `all-items-completed [list_id]` - Checks if all items are done/cancelled
-- `archive-todo-list [list_id]` - Creates note and archives list
-- Modified `update-item-status` - Triggers auto-archive when last item completes
-
-**Formatters Added**:
-- `format-item-updated-with-archive` - Shows archive confirmation with status update
-- `format-item-completed-with-archive` - Shows archive confirmation with completion
-
-**Archive Note Content**:
-```markdown
-# <todo list name>
-
-<todo list description>
-
-## Completed Items
-- ✅ <item content> (completed: <timestamp>)  # done items
-- ❌ <item content> (completed: <timestamp>)  # cancelled items
-
-## Progress Notes
-<todo list notes field>
-
----
-*Auto-archived on <timestamp>*
-```
-
-**Auto-Archive Trigger**:
-- When `update-item-status` or `complete-item` changes last pending item to done/cancelled
-- Checks if all items completed using COUNT(*) query
-- Creates note with `note_type='archived_todo'`
-- Updates list: `status='archived'`, sets `archived_at` timestamp
-- User sees special message with note ID
-
-**Bug Fixes**:
-- Disabled FTS (full-text search) until Milestone 7 - TEXT IDs incompatible with FTS rowid
-- Fixed empty list handling in `get-active-lists`
-- Added `notes` field to `get-list-with-items` SELECT query
-- Escaped parentheses and asterisk in SQL strings for Nushell parsing
-
-**Acceptance Criteria**:
-- [x] When last item completes, list auto-archives
-- [x] Note created with note_type='archived_todo'
-- [x] Note content includes all completed items with timestamps and emojis
-- [x] Note content includes description and progress notes
-- [x] Source_id points to original todo list ID
-- [x] Todo list status changes to 'archived'
-- [x] Archived_at timestamp set automatically
-- [x] Archived lists don't appear in c5t_list_active
-- [x] Tags preserved from list to note
-- [x] 64 tests passing (61 from M4 + 3 new tests)
-
-**Status**: ✅ COMPLETE (commit pending)
-
----
-
-### Milestone 6: Standalone Notes
-**Goal**: Create and manage manual notes
-
-**Tools Implemented**:
-- `c5t_create_note` - Create standalone note with title, content, and optional tags
-- `c5t_list_notes` - List notes with optional tag filter, note_type filter, and limit
-- `c5t_get_note` - Get specific note by ID with full content
-
-**Functions Implemented** (storage.nu, kebab-case):
-- `create-note [title, content, tags?]` - Creates manual note, returns {success, id, title, tags}
-- `get-notes [tag_filter?: list, note_type?, limit?]` - Filters by tags (ANY match), note_type, and limit
-- `get-note-by-id [note_id]` - Returns {success, note} or {success: false, error}
-
-**Formatters Added**:
-- `format-note-created-manual [result]` - Confirmation with ID and tags
-- `format-notes-list-detailed [notes]` - List view with emoji indicators (📝 manual, 🗃️ archived_todo)
-- `format-note-detail [note]` - Full note view with metadata and complete content
-
-**Validation**:
-```bash
-nu tools/c5t/mod.nu call-tool c5t_create_note '{
-  "title": "Database Design Decision",
-  "content": "# Why SQLite\n\nChose SQLite for...",
-  "tags": ["architecture", "database"]
-}'
-
-nu tools/c5t/mod.nu call-tool c5t_list_notes '{
-  "tags": ["architecture"],
-  "limit": 10
-}'
-
-nu tools/c5t/mod.nu call-tool c5t_get_note '{
-  "note_id": "20250114163000-9999"
-}'
-```
-
-**Acceptance Criteria**:
-- [x] Can create notes with markdown content
-- [x] Can list notes with tag filtering (ANY tag match)
-- [x] Can filter by note_type (manual, archived_todo, scratchpad)
-- [x] Can retrieve specific note by ID with full content
-- [x] Note_type defaults to 'manual'
-- [x] Timestamps set correctly (created_at, updated_at)
-- [x] Tags stored as JSON array
-- [x] Formatters include emoji indicators by note type
-- [x] Content preview in list view (100 chars)
-- [x] 76 tests passing (64 from M5 + 12 new tests)
-
-**Status**: ✅ COMPLETE
-
----
-
-### Milestone 7: Full-Text Search
-**Goal**: Search notes by content and title using FTS5
-
-**Tools Implemented**:
-- `c5t_search` - Full-text search using FTS5 with boolean operators and tag filtering
-
-**Functions Implemented** (storage.nu, kebab-case):
-- `search-notes [query, --limit, --tags]` - FTS5 search with bm25 ranking, client-side tag filtering
-
-**FTS5 Implementation**:
-- Virtual table `note_fts` created with INTEGER rowid compatibility (enabled in 0001_initial_schema.sql)
-- Triggers sync inserts/updates/deletes automatically
-- Searches both title and content fields
-- BM25 relevance ranking (lower scores = better matches)
-- Supports FTS5 query syntax:
-  - Simple terms: `"database"`
-  - Boolean: `"api AND database"`, `"auth OR user"`
-  - Phrases: `"error handling"`
-  - Prefix: `"auth*"` (matches "authentication", "authorize", etc.)
-  - NOT operator: `"api NOT deprecated"`
-
-**Formatter**:
-- Uses existing `format-search-results` (formatters.nu:121)
-
-**Tests Implemented** (test_storage.nu):
-- `test search-notes basic query returns results` - Single term search
-- `test search-notes respects limit parameter` - LIMIT clause
-- `test search-notes filters by tags` - Client-side tag filtering
-- `test search-notes returns empty list when no matches` - Empty results
-- `test search-notes with boolean AND query` - FTS5 boolean operators
-
-**Validation**:
-```bash
-nu tools/c5t/mod.nu call-tool c5t_search '{
-  "query": "database",
-  "limit": 10
-}'
-
-nu tools/c5t/mod.nu call-tool c5t_search '{
-  "query": "authentication AND api",
-  "tags": ["backend"]
-}'
-
-nu tools/c5t/mod.nu call-tool c5t_search '{
-  "query": "auth*"
-}'
-```
-
-**SQL Query**:
-```sql
-SELECT 
-  note.id, note.title, note.content, note.tags, note.note_type, note.created_at,
-  bm25(note_fts) as rank
-FROM note_fts
-JOIN note ON note.id = note_fts.rowid
-WHERE note_fts MATCH '<query>'
-ORDER BY rank
-LIMIT <limit>;
-```
-
-**Acceptance Criteria**:
-- [x] FTS5 full-text search works
-- [x] Searches both title and content
-- [x] Can combine with tag filtering (client-side after FTS query)
-- [x] Results sorted by relevance (bm25 ranking)
-- [x] Limit parameter works (default: 10)
-- [x] Supports boolean operators (AND, OR, NOT)
-- [x] Supports phrase queries
-- [x] Supports prefix matching
-- [x] 79 tests passing (74 from M6 + 5 new search tests)
-
-**Status**: ✅ COMPLETE
-
----
-
-### Milestone 8: Scratchpad
-**Goal**: Auto-updating context scratchpad
-
-**Tools Implemented**:
-- `c5t_update_scratchpad` - Update or create scratchpad note
-- `c5t_get_scratchpad` - Retrieve current scratchpad
-
-**Functions Implemented** (storage.nu, kebab-case):
-- `update-scratchpad [content]` - UPDATE existing or INSERT new scratchpad (only one exists)
-- `get-scratchpad` - Returns scratchpad or null if none exists
-
-**Modified Functions**:
-- `get-notes` - Now excludes scratchpad by default unless explicitly requested with `note_type='scratchpad'`
-
-**Tests Implemented** (test_storage.nu):
-- `test update-scratchpad creates new scratchpad when none exists` - INSERT path
-- `test update-scratchpad updates existing scratchpad` - UPDATE path
-- `test get-scratchpad returns current scratchpad` - Happy path
-- `test get-scratchpad returns null when no scratchpad exists` - Empty case
-- `test only one scratchpad exists after multiple updates` - Ensures single scratchpad
-- `test get-notes excludes scratchpad by default` - Default filtering
-- `test get-notes includes scratchpad when explicitly requested` - Explicit note_type
-
-**Validation**:
-```bash
-# Test scratchpad creation
-nu tools/c5t/mod.nu call-tool c5t_update_scratchpad '{
-  "content": "## Current Work\n\nWorking on Milestone 8"
-}'
-
-# Test scratchpad retrieval
-nu tools/c5t/mod.nu call-tool c5t_get_scratchpad '{}'
-
-# Verify excluded from default list
-nu tools/c5t/mod.nu call-tool c5t_list_notes '{}'
-
-# Explicitly request scratchpad
-nu tools/c5t/mod.nu call-tool c5t_list_notes '{"note_type": "scratchpad"}'
-```
-
-**Acceptance Criteria**:
-- [x] Only one scratchpad note exists (enforced by update-scratchpad logic)
-- [x] Update replaces previous scratchpad (UPDATE path tested)
-- [x] Scratchpad has note_type='scratchpad' (enforced in SQL INSERT/UPDATE)
-- [x] Scratchpad excluded from default c5t_list_notes (WHERE note_type != 'scratchpad')
-- [x] Can retrieve scratchpad with c5t_get_scratchpad
-- [x] Can explicitly list scratchpad with note_type filter
-- [x] 85 tests passing (79 from M7 + 6 new scratchpad tests)
-
-**Implementation Note**: 
-- Manual trigger for MVP (user calls `c5t_update_scratchpad` with generated content)
-- Content generation (active todos, recent notes, etc.) is responsibility of the caller/LLM
-- Future: Could add `generate-scratchpad-content` helper function
-
-**Status**: ✅ COMPLETE
-
----
-
-### Milestone 9: Formatters & Output
-**Goal**: User-friendly output formatting
-
-**Functions Implemented** (formatters.nu, kebab-case):
-- `format-list-created [result]` - Create response with tags and description
-- `format-active-lists [lists]` - List active todo lists with tags, description, notes
-- `format-items-list [list items]` - Items grouped by status with emojis and counts
-- `format-note-created-manual [result]` - Note creation with tags
-- `format-notes-list-detailed [notes]` - Notes with type emoji, tags, preview
-- `format-note-detail [note]` - Full note view with metadata and content
-- `format-search-results [notes]` - Search results with basic info
-- `format-item-created [result]` - Item creation with priority
-- `format-item-updated [field item_id value]` - Update confirmation
-- `format-item-completed [item_id]` - Completion confirmation
-- `format-item-updated-with-archive [...]` - Update + archive notification
-- `format-item-completed-with-archive [...]` - Complete + archive notification
-- `format-notes-updated [list_id]` - Notes update confirmation
-
-**Features**:
-- Status-based grouping with emojis (📋 Backlog, 📝 To Do, 🔄 In Progress, 👀 Review, ✅ Done, ❌ Cancelled)
-- Type emojis for notes (📝 manual, 🗃️ archived_todo, 📋 scratchpad)
-- Counts per status group (e.g., "Done (3)")
-- Content previews (100 chars)
-- Timestamp display
-- Tag formatting
-- Priority indicators [P1-P5]
-- Auto-archive notifications with note ID
-
-**Acceptance Criteria**:
-- [x] Todo lists show progress (status counts per group)
-- [x] Notes show title, tags, preview (format-notes-list-detailed)
-- [x] Search results show matched snippets (basic info shown)
-- [x] Timestamps formatted for readability (from SQLite, human-readable)
-- [x] Markdown content displayed appropriately (full content in format-note-detail)
-- [x] Emojis for visual clarity
-- [x] Consistent formatting across all tools
-
-**Status**: ✅ COMPLETE
-
----
-
-### Milestone 10: Error Handling & Validation
-**Goal**: Robust error handling and input validation
-
-**Functions Implemented** (utils.nu, kebab-case):
-- `validate-list-input [args]` - Validates name field (required, non-empty)
-- `validate-item-input [args]` - Validates list_id and content (required, non-empty)
-- `validate-note-input [args]` - Validates title and content (required, non-empty)
-- `validate-item-update-input [args]` - Validates list_id and item_id (required)
-- `validate-status [status]` - Validates status against allowed values
-- `validate-priority [priority]` - Validates priority (1-5 range)
-
-**Error Handling in storage.nu**:
-- All database operations wrapped in try-catch
-- Consistent error format: `{success: false, error: "message"}`
-- 25+ error return points with descriptive messages
-- SQL escaping for single quotes (prevents injection)
-- Null/empty checks before processing
-
-**Error Handling in mod.nu**:
-- Validation before calling storage functions
-- Required field checks (23+ checks)
-- Not-found checks after database queries
-- User-friendly error messages returned to LLM
-- Suggestions in validation errors (e.g., "Must be one of: backlog, todo, ...")
-
-**Error Scenarios Covered**:
-- [x] Todo list not found (checked after query, e.g., mod.nu:380)
-- [x] Todo item not found (checked after query, e.g., mod.nu:414)
-- [x] Invalid list_id format (validated via validate-item-update-input)
-- [x] Empty title/name (validate-list-input, validate-note-input)
-- [x] Invalid tags format (handled by Nushell type system - array expected)
-- [x] Database not initialized (auto-initialized in list-tools via init-database)
-- [x] Invalid status (validate-status with suggestions)
-- [x] Invalid priority (validate-priority with range message)
-- [x] Missing required fields (all tools check before processing)
-- [x] SQL errors (try-catch in execute-sql and query-sql)
-
-**Acceptance Criteria**:
-- [x] Clear error messages for all failure cases
-- [x] Input validation before database operations (all tools validate first)
-- [x] Helpful suggestions in error messages (status/priority show valid values)
-- [x] Try-catch around all database operations (execute-sql, query-sql)
-- [x] Consistent error format across all functions
-- [x] SQL injection protection (single quote escaping)
-
-**Status**: ✅ COMPLETE
-
----
-
-### Milestone 11: Documentation
-**Goal**: Complete README and usage examples
-
-**Files Created**:
-- [x] `tools/c5t/README.md` - Succinct documentation with all essential information
-
-**Documentation Sections Included**:
-- [x] Tool overview and purpose
-- [x] Installation (auto-discovered by nu-mcp)
-- [x] Configuration (database location)
-- [x] All 15 available tools listed
-- [x] Todo workflow with complete example
-- [x] Notes workflow with examples
-- [x] Scratchpad usage and behavior
-- [x] FTS5 search syntax and examples
-- [x] Auto-archive explanation
-- [x] Database structure
-- [x] End-to-end example workflow
-
-**Acceptance Criteria**:
-- [x] README complete with all sections
-- [x] Code examples tested (manual workflow verified all examples)
-- [x] Clear explanation of auto-archive
-- [x] Scratchpad explained (single note, excluded from default list)
-- [x] All 15 tools documented
-
-**Status**: ✅ COMPLETE
-
----
-
-### Milestone 12: Testing & Polish
-**Goal**: Comprehensive testing and code quality
-
-**Testing Completed**:
-
-1. **Todo Lists**:
-   - [x] Create → Add items → Complete all → Verify archive (manual test verified)
-   - [x] Multiple items with different priorities
-   - [x] Update notes field (verified in manual test)
-   - [x] All 6 statuses work correctly
-   
-2. **Notes**:
-   - [x] Create manual note with markdown
-   - [x] List with tag filtering
-   - [x] Search across notes with FTS5
-   - [x] Retrieve archived todo as note
-   
-3. **Scratchpad**:
-   - [x] Update scratchpad multiple times
-   - [x] Retrieve scratchpad
-   - [x] Only one scratchpad exists (enforced by logic)
-   - [x] Excluded from default list_notes
-   - [x] Included when explicitly requested
-   
-4. **Unit Tests**:
-   - [x] 85/85 tests passing
-   - [x] All create operations return correct IDs
-   - [x] Mocks enhanced to handle chained SQL
-   - [x] No mock fallbacks in production code
-
-5. **Critical Bug Fixed**:
-   - [x] last_insert_rowid() bug (separate connection issue)
-   - [x] Chained INSERT + SELECT in same sqlite3 call
-   - [x] All IDs now match database reality
-
-6. **Manual End-to-End Testing**:
-   - [x] Full developer workflow tested
-   - [x] Auto-archive triggered correctly
-   - [x] All formatters display properly
-   - [x] Search with boolean operators works
-   - [x] Scratchpad workflow verified
-
-**Status**: ✅ COMPLETE
-
-**Code Quality**:
-- [ ] Format all Nushell files with topiary
-- [ ] Run clippy and fix warnings
-- [ ] Follow naming conventions (snake_case tools, kebab-case functions)
-- [ ] Add comments for complex logic
-
----
-
-## Tool Schemas (MCP)
-
-### Todo Management
-
-**c5t_create_list**:
-```nushell
-{
-    name: "c5t_create_list"
-    description: "Create a new todo list to track work"
-    input_schema: {
-        type: "object"
-        properties: {
-            name: { type: "string", description: "List name" }
-            description: { type: "string", description: "Brief description" }
-            tags: { 
-                type: "array", 
-                items: { type: "string" },
-                description: "Tags for categorization"
-            }
-        }
-        required: ["name"]
-    }
-}
-```
-
-**c5t_add_item**:
-```nushell
-{
-    name: "c5t_add_item"
-    description: "Add a todo item to a list (defaults to 'todo' status)"
-    input_schema: {
-        type: "object"
-        properties: {
-            list_id: { type: "string", description: "Todo list ID" }
-            content: { type: "string", description: "Item description" }
-            status: { 
-                type: "string", 
-                enum: ["backlog", "todo", "in_progress", "review", "done", "cancelled"],
-                description: "Initial status (default: 'todo')" 
-            }
-        }
-        required: ["list_id", "content"]
-    }
-}
-```
-
-**c5t_update_item_status**:
-```nushell
-{
-    name: "c5t_update_item_status"
-    description: "Update todo item status (e.g., todo → in_progress → done)"
-    input_schema: {
-        type: "object"
-        properties: {
-            list_id: { type: "string", description: "Todo list ID" }
-            item_id: { type: "string", description: "Item ID" }
-            status: {
-                type: "string",
-                enum: ["backlog", "todo", "in_progress", "review", "done", "cancelled"],
-                description: "New status for the item"
-            }
-        }
-        required: ["list_id", "item_id", "status"]
-    }
-}
-```
-
-**c5t_complete_item**:
-```nushell
-{
-    name: "c5t_complete_item"
-    description: "Mark item as done (shortcut for status='done'). Auto-archives list if all items done."
-    input_schema: {
-        type: "object"
-        properties: {
-            list_id: { type: "string", description: "Todo list ID" }
-            item_id: { type: "string", description: "Item ID" }
-        }
-        required: ["list_id", "item_id"]
-    }
-}
-```
-
-**c5t_update_notes**:
-```nushell
-{
-    name: "c5t_update_notes"
-    description: "Update progress notes on a todo list (markdown supported)"
-    input_schema: {
-        type: "object"
-        properties: {
-            list_id: { type: "string", description: "Todo list ID" }
-            notes: { type: "string", description: "Progress notes (markdown)" }
-        }
-        required: ["list_id", "notes"]
-    }
-}
-```
-
-**c5t_list_active**:
-```nushell
-{
-    name: "c5t_list_active"
-    description: "List all active todo lists"
-    input_schema: {
-        type: "object"
-        properties: {
-            tags: {
-                type: "array",
-                items: { type: "string" },
-                description: "Filter by tags (optional)"
-            }
-        }
-    }
-}
-```
-
-### Notes Management
-
-**c5t_create_note**:
-```nushell
-{
-    name: "c5t_create_note"
-    description: "Create a standalone note (markdown supported)"
-    input_schema: {
-        type: "object"
-        properties: {
-            title: { type: "string", description: "Note title" }
-            content: { type: "string", description: "Note content (markdown)" }
-            tags: {
-                type: "array",
-                items: { type: "string" },
-                description: "Tags (optional)"
-            }
-        }
-        required: ["title", "content"]
-    }
-}
-```
-
-**c5t_list_notes**:
-```nushell
-{
-    name: "c5t_list_notes"
-    description: "List notes with filtering"
-    input_schema: {
-        type: "object"
-        properties: {
-            tags: {
-                type: "array",
-                items: { type: "string" },
-                description: "Filter by tags"
-            }
-            note_type: {
-                type: "string",
-                enum: ["manual", "archived_todo", "scratchpad", "all"],
-                description: "Filter by type (default: all except scratchpad)"
-            }
-            limit: {
-                type: "integer",
-                minimum: 1,
-                maximum: 100,
-                description: "Max notes to return (default: 20)"
-            }
-        }
-    }
-}
-```
-
-**c5t_get_note**:
-```nushell
-{
-    name: "c5t_get_note"
-    description: "Get a specific note by ID"
-    input_schema: {
-        type: "object"
-        properties: {
-            note_id: { type: "string", description: "Note ID" }
-        }
-        required: ["note_id"]
-    }
-}
-```
-
-**c5t_search**:
-```nushell
-{
-    name: "c5t_search"
-    description: "Full-text search in notes"
-    input_schema: {
-        type: "object"
-        properties: {
-            query: { type: "string", description: "Search query" }
-            tags: {
-                type: "array",
-                items: { type: "string" },
-                description: "Also filter by tags (optional)"
-            }
-            limit: {
-                type: "integer",
-                minimum: 1,
-                maximum: 100,
-                description: "Max results (default: 20)"
-            }
-        }
-        required: ["query"]
-    }
-}
-```
-
-### Scratchpad
-
-**c5t_update_scratchpad**:
-```nushell
-{
-    name: "c5t_update_scratchpad"
-    description: "Update the session scratchpad (for context preservation)"
-    input_schema: {
-        type: "object"
-        properties: {
-            content: { type: "string", description: "Scratchpad content (markdown)" }
-        }
-        required: ["content"]
-    }
-}
-```
-
-**c5t_get_scratchpad**:
-```nushell
-{
-    name: "c5t_get_scratchpad"
-    description: "Get the current scratchpad content"
-    input_schema: {
-        type: "object"
-        properties: {}
-    }
-}
-```
-
-## Testing Approach
-
-### Manual Testing Commands
-
-```bash
-# Test database creation
-nu tools/c5t/mod.nu list-tools
-
-# Test todo workflow
-nu tools/c5t/mod.nu call-tool c5t_create_list '{"name": "Test", "tags": ["test"]}'
-nu tools/c5t/mod.nu call-tool c5t_add_item '{"list_id": "...", "content": "Item 1"}'
-nu tools/c5t/mod.nu call-tool c5t_complete_item '{"list_id": "...", "item_id": "..."}'
-nu tools/c5t/mod.nu call-tool c5t_list_active '{}'
-
-# Test notes
-nu tools/c5t/mod.nu call-tool c5t_create_note '{
-  "title": "Test Note",
-  "content": "# Test\n\nContent",
-  "tags": ["test"]
-}'
-nu tools/c5t/mod.nu call-tool c5t_search '{"query": "test"}'
-
-# Test scratchpad
-nu tools/c5t/mod.nu call-tool c5t_update_scratchpad '{"content": "## Session\n\nWorking on..."}'
-nu tools/c5t/mod.nu call-tool c5t_get_scratchpad '{}'
-```
-
-### Edge Cases to Test
-
-- [ ] Create list without tags
-- [ ] Add item to non-existent list
-- [ ] Complete already completed item
-- [ ] Complete item in archived list
-- [ ] Search with no results
-- [ ] List notes from empty database
-- [ ] Update scratchpad multiple times (should replace)
-
-## Questions & Decisions
-
-### Database Location
-**Decision**: Use `.c5t/context.db` in project root (per-project storage)
-**Rationale**: Context is project-specific; separate databases prevent mixing unrelated work
-
-### Auto-Archive Trigger
-**Decision**: Automatically archive when last item is completed
-**Rationale**: Simplifies workflow; completed work becomes searchable knowledge immediately
-
-### Scratchpad Updates
-**Question**: How to trigger at 25% context intervals?
-**MVP Decision**: Manual trigger via `c5t_update_scratchpad`
-**Future**: Hook into OpenCode's context tracking if API available
-
-### Export/Import
-**Decision**: Defer to future iteration
-**Rationale**: Focus on core workflow first; export/import needed for backup/sync but not MVP
-
-### Markdown Rendering
-**Decision**: Store as-is, no rendering in tool output
-**Rationale**: MCP clients may render markdown; tool just preserves format
-
-### Tag Storage
-**Decision**: JSON array as TEXT in SQLite
-**Rationale**: Simple, queryable with SQLite JSON functions, easy to export
-
-## Success Criteria
-
-- [ ] Can create and manage todo lists
-- [ ] Auto-archive works when all items complete
-- [ ] Can create and search markdown notes
-- [ ] Scratchpad updates and retrieves correctly
-- [ ] Full-text search works across notes
-- [ ] Database persists across sessions
-- [ ] All tests pass
-- [ ] Documentation complete
-- [ ] Code formatted with topiary
-
-## Timeline Estimate
-
-- Milestone 1 (Structure & DB): 30 minutes
-- Milestone 2 (Create Lists): 30 minutes
-- Milestone 3 (Items): 30 minutes
-- Milestone 4 (Notes Update): 15 minutes
-- Milestone 5 (Auto-Archive): 45 minutes
-- Milestone 6 (Standalone Notes): 30 minutes
-- Milestone 7 (Search): 30 minutes
-- Milestone 8 (Scratchpad): 30 minutes
-- Milestone 9 (Formatters): 30 minutes
-- Milestone 10 (Error Handling): 30 minutes
-- Milestone 11 (Documentation): 30 minutes
-- Milestone 12 (Testing): 45 minutes
-
-**Total**: ~6 hours
-
-## Future Enhancements (Post-MVP)
-
-### Kanban Visualization
-- `c5t_get_board` - Visualize items as Kanban board with columns
-- `c5t_move_item` - Move items between status columns
-- ASCII/Unicode board rendering for CLI display
-- WIP limits per status column
-- Drag-and-drop position ordering within columns
-- Swimlanes (group by tag or priority)
-
-### Data Management
-- Export to JSON (with markdown content)
-- Import from JSON exports
-- Backup and restore functionality
-
-### Note Enhancements
-- Links between notes (Obsidian-style `[[note-title]]`)
-- Backlinks (what references this note?)
-- Note templates
-- Attachments/file references
-
-### Workflow
-- Batch operations (archive multiple lists)
-- Statistics (completion rates, velocity, etc.)
-- Integration with TodoWrite tool
-- Recurring tasks
+## Key Changes from Original Plan
+
+1. **Removed auto-archive**: Too complex, manual workflow preferred
+2. **Removed scratchpad**: Session notes pattern with tags is more flexible
+3. **Renamed todo_list/todo_item to task_list/task**: Clearer terminology
+4. **Added subtasks**: Via parent_id self-referential FK
+5. **Added project isolation**: Via repo table and git remote detection
+6. **Added export/import**: JSON backup with v2.0 format
+7. **Changed IDs**: From TEXT UUIDs to INTEGER auto-increment
+8. **Status filter**: Changed from single enum to array of statuses
+9. **Removed position column**: Unnecessary complexity
+10. **Native table output**: Switched from markdown to Nushell tables
+
+## Future Enhancements
+
+### Potential Additions
+- Kanban board visualization (`get_board` tool)
+- Task templates
 - Due dates and reminders
+- Links between notes (Obsidian-style)
+- Statistics and velocity tracking
+- Recurring tasks
+
+### Not Planned
+- Auto-archive (removed as too complex)
+- Dedicated scratchpad (session notes pattern preferred)
+- Position/ordering within lists (removed)
 
 ## References
 
-- Nushell SQLite Documentation: https://www.nushell.sh/book/loading_data.html
-- SQLite FTS5: https://www.sqlite.org/fts5.html
-- Tool Development Guide: `docs/tool-development.md`
-- ArgoCD Implementation Plan (reference): `docs/implementation-plans/argocd-cli-auth.md`
+- [Tool README](../../tools/c5t/README.md)
+- [Tool Development Guide](../tool-development.md)
+- [Nushell SQLite Documentation](https://www.nushell.sh/book/loading_data.html)
+- [SQLite FTS5](https://www.sqlite.org/fts5.html)

--- a/tools/c5t/README.md
+++ b/tools/c5t/README.md
@@ -5,16 +5,22 @@ Context preservation across LLM sessions using SQLite and Nushell.
 ## Overview
 
 c5t (Context) helps LLMs maintain state across sessions by providing:
-- **Todo Lists**: Kanban-style task tracking with 6 statuses
+- **Task Lists**: Kanban-style task tracking with 6 statuses
+- **Subtasks**: Break down complex tasks into smaller pieces
 - **Notes**: Persistent markdown documentation
-- **Auto-Archive**: Completed todo lists become searchable notes
 - **Full-Text Search**: FTS5 search with boolean operators
 - **Session Notes**: Use tag 'session' for context that persists across conversations
 - **Project Isolation**: Data is scoped per git repository (via remote URL)
+- **Export/Import**: Backup and restore all data
 
 ## Quick Start
 
-The tool auto-initializes on first use.
+The tool auto-initializes on first use. Register your repository first:
+
+```bash
+# Register the current git repository
+upsert_repo {}
+```
 
 ### Storage Location
 
@@ -26,38 +32,44 @@ The tool auto-initializes on first use.
 c5t automatically isolates data by git repository. When you run a c5t command:
 1. It detects the current git remote URL (e.g., `git@github.com:org/repo.git`)
 2. Normalizes it to a project identifier (e.g., `github:org/repo`)
-3. All todo lists and notes are scoped to that project
+3. All task lists and notes are scoped to that project
 
 This means:
-- Different repositories have separate todo lists and notes
+- Different repositories have separate task lists and notes
 - Cloning a repo in a new location auto-links to existing data
-- Use `--all-repos` flag to query across all projects
+- Use `all_repos: true` parameter to query across all projects
 
-## Todo Workflow
+## Task Workflow
 
 ```bash
+# Register repo first (required before creating lists/notes)
+upsert_repo {}
+
 # Create a list (upsert without list_id creates new)
-c5t_upsert_list {"name": "API Feature", "tags": ["backend", "urgent"]}
-# → ID: 1
+upsert_task_list {"name": "API Feature", "tags": ["backend", "urgent"]}
+# -> ID: 1
 
 # Update a list (upsert with list_id updates existing)
-c5t_upsert_list {"list_id": 1, "name": "API Feature v2", "description": "Updated desc"}
+upsert_task_list {"list_id": 1, "name": "API Feature v2", "description": "Updated desc"}
 
-# Add items (upsert without item_id creates new)
-c5t_upsert_item {"list_id": 1, "content": "Research JWT", "priority": 1}
-c5t_upsert_item {"list_id": 1, "content": "Implement login"}
+# Add tasks (upsert without task_id creates new)
+upsert_task {"list_id": 1, "content": "Research JWT", "priority": 1}
+upsert_task {"list_id": 1, "content": "Implement login"}
 
-# Update item (upsert with item_id updates existing - can change content, priority, status)
-c5t_upsert_item {"list_id": 1, "item_id": 1, "content": "Research JWT libs", "status": "in_progress"}
+# Update task (upsert with task_id updates existing - can change content, priority, status)
+upsert_task {"list_id": 1, "task_id": 1, "content": "Research JWT libs", "status": "in_progress"}
 
-# View list with items grouped by status
-c5t_list_items {"list_id": 1}
+# View list with tasks grouped by status
+list_tasks {"list_id": 1}
 
-# Update item status (backlog → todo → in_progress → review → done → cancelled)
-c5t_update_item_status {"list_id": 1, "item_id": 1, "status": "done"}
+# Filter by status (array of statuses)
+list_tasks {"list_id": 1, "status": ["todo", "in_progress"]}
 
-# Add progress notes
-c5t_update_notes {"list_id": 1, "notes": "## Progress\n\nCompleted research"}
+# Complete a task
+complete_task {"list_id": 1, "task_id": 1}
+
+# Add progress notes to the list
+upsert_task_list {"list_id": 1, "notes": "## Progress\n\nCompleted research"}
 ```
 
 **Statuses**: `backlog`, `todo`, `in_progress`, `review`, `done`, `cancelled`
@@ -74,7 +86,7 @@ Break down complex tasks into smaller pieces:
 ```bash
 # Create a parent task
 upsert_task {"list_id": 1, "content": "Implement authentication"}
-# → ID: 1
+# -> ID: 1
 
 # Create subtasks with parent_id
 upsert_task {"list_id": 1, "parent_id": 1, "content": "Research JWT libraries"}
@@ -86,7 +98,7 @@ list_tasks {"list_id": 1, "parent_id": 1}
 
 # List tasks shows subtask count
 list_tasks {"list_id": 1}
-# → Parent tasks show "(3 subtasks)" indicator
+# -> Parent tasks show "(3 subtasks)" indicator
 ```
 
 **Notes:**
@@ -94,39 +106,40 @@ list_tasks {"list_id": 1}
 - Subtasks can have their own priority and status
 - Parent tasks show subtask count in task lists
 - Use `list_tasks` with `parent_id` to view subtasks for a specific parent
+- Deleting a parent task cascades to delete all subtasks
 
 ## Notes Workflow
 
 ```bash
 # Create note (upsert without note_id creates new)
-c5t_upsert_note {
+upsert_note {
   "title": "Architecture Decision",
   "content": "We decided to use Rust for performance",
   "tags": ["architecture", "backend"]
 }
 
 # Update note (upsert with note_id updates existing)
-c5t_upsert_note {
+upsert_note {
   "note_id": 1,
   "content": "Updated: We decided to use Rust for both performance and safety"
 }
 
 # List notes
-c5t_list_notes {}
-c5t_list_notes {"tags": ["backend"]}
-c5t_list_notes {"note_type": "manual"}  # Filter by type
+list_notes {}
+list_notes {"tags": ["backend"]}
+list_notes {"note_type": "manual"}  # Filter by type
 
 # Get specific note
-c5t_get_note {"note_id": 1}
+get_note {"note_id": 1}
 
 # Search with FTS5
-c5t_search {"query": "architecture"}
-c5t_search {"query": "rust AND performance"}  # Boolean operators
-c5t_search {"query": "auth*"}  # Prefix matching
-c5t_search {"query": "api", "tags": ["backend"]}  # With tag filter
+search {"query": "architecture"}
+search {"query": "rust AND performance"}  # Boolean operators
+search {"query": "auth*"}  # Prefix matching
+search {"query": "api", "tags": ["backend"]}  # With tag filter
 ```
 
-**Note Types**: `manual`
+**Note Types**: `manual`, `archived_todo` (from completed task lists)
 
 ## Session Notes Pattern
 
@@ -134,23 +147,23 @@ Instead of a dedicated scratchpad, use regular notes with the `session` tag to m
 
 ```bash
 # Create a session note to track current work
-c5t_upsert_note {
+upsert_note {
   "title": "Session: Auth Feature - 2025-01-15",
   "content": "## Current Work\n\n- Working on auth feature\n- Next: rate limiting",
   "tags": ["session"]
 }
 
 # Update an existing session note (provide note_id)
-c5t_upsert_note {
+upsert_note {
   "note_id": 1,
   "content": "## Current Work\n\n- Auth feature complete\n- Next: rate limiting"
 }
 
 # Find session notes when context is lost
-c5t_list_notes {"tags": ["session"]}
+list_notes {"tags": ["session"]}
 
 # Or search for session context
-c5t_search {"query": "current work", "tags": ["session"]}
+search {"query": "current work", "tags": ["session"]}
 ```
 
 ### Session Note Template
@@ -161,8 +174,8 @@ c5t_search {"query": "current work", "tags": ["session"]}
 ## Current Work
 [What you're actively working on right now]
 
-## Active Todo Lists
-- List: [Name] (ID: X) - [X items: Y in progress, Z todo]
+## Active Task Lists
+- List: [Name] (ID: X) - [X tasks: Y in progress, Z todo]
 
 ## Key Decisions & Learnings
 - [Important decision made and reasoning]
@@ -184,43 +197,48 @@ Last updated: [timestamp]
 - Create session notes at major milestones
 - Use the `session` tag consistently
 - Include reasoning behind decisions, not just facts
-- Use `c5t_list_notes {"tags": ["session"]}` at session start for context recovery
+- Use `list_notes {"tags": ["session"]}` at session start for context recovery
 
 ## All Available Tools
 
+### Repository Management
+- `upsert_repo` - Register or update a git repository (required before creating lists/notes)
+- `list_repos` - List all known repositories
+
 ### Task Lists
 - `upsert_task_list` - Create or update a list (omit list_id to create, provide to update). Supports name, description, tags, and progress notes.
-- `list_task_lists` - List active lists
+- `list_task_lists` - List task lists with status counts
 - `get_task_list` - Get list metadata without tasks
 - `delete_task_list` - Remove a list (use force=true if has tasks)
+
+### Tasks
 - `upsert_task` - Create or update a task (omit task_id to create, provide to update). Can set content, priority, status, parent_id for subtasks.
-- `list_tasks` - View tasks grouped by status (shows subtask count). Use `parent_id` param to list subtasks.
+- `list_tasks` - View tasks grouped by status (shows subtask count). Use `parent_id` param to list subtasks. Use `status` array param to filter.
 - `complete_task` - Mark task done (shortcut for status='done')
 - `delete_task` - Remove a task
 - `move_task` - Move task to another list
 
 ### Notes
-- `c5t_upsert_note` - Create or update a note (omit note_id to create, provide to update)
-- `c5t_list_notes` - List notes, filter by tags or type
-- `c5t_get_note` - Get specific note by ID
-- `c5t_delete_note` - Remove a note
-- `c5t_search` - Full-text search with FTS5
+- `upsert_note` - Create or update a note (omit note_id to create, provide to update)
+- `list_notes` - List notes, filter by tags or type
+- `get_note` - Get specific note by ID
+- `delete_note` - Remove a note
+- `search` - Full-text search with FTS5
 
 ### Summary
-- `c5t_get_summary` - Quick status overview of active work
+- `get_summary` - Quick status overview of active work, including recently completed tasks
 
 ### Data Management
-- `c5t_export_data` - Export all data to `~/.local/share/c5t/backups/backup-{timestamp}.json`
-- `c5t_list_backups` - List available backup files
-- `c5t_import_data` - Import data from backup file (merge or replace)
-- `c5t_list_repos` - List all known repositories
+- `export_data` - Export all data to `~/.local/share/c5t/backups/backup-{timestamp}.json`
+- `list_backups` - List available backup files
+- `import_data` - Import data from backup file (replaces all existing data)
 
 ## Database
 
 - **Location**: `~/.local/share/c5t/context.db` (respects `XDG_DATA_HOME`)
 - **Backups**: `~/.local/share/c5t/backups/`
 - **Schema**: SQLite with INTEGER PRIMARY KEYs
-- **Tables**: `repo`, `todo_list`, `todo_item`, `note`, `note_fts` (FTS5)
+- **Tables**: `repo`, `task_list`, `task`, `note`, `note_fts` (FTS5)
 - **Migration**: Auto-applies on initialization
 
 ## Project Isolation
@@ -237,27 +255,30 @@ c5t uses git remote URLs to identify projects:
 
 ### Querying Across Projects
 
-Most read operations support an `allRepos` flag to query across all projects:
+Most read operations support an `all_repos` flag to query across all projects:
 
 ```bash
-# View todos from current repo only (default)
-c5t_list_active {}
+# View task lists from current repo only (default)
+list_task_lists {}
 
-# View todos from ALL repositories
-c5t_list_active {"allRepos": true}
+# View task lists from ALL repositories
+list_task_lists {"all_repos": true}
 
 # Search notes across all projects
-c5t_search {"query": "auth", "allRepos": true}
+search {"query": "auth", "all_repos": true}
 
 # Get summary across all projects
-c5t_get_summary {"allRepos": true}
+get_summary {"all_repos": true}
 ```
 
 ### Managing Repositories
 
 ```bash
+# Register current directory's git repo
+upsert_repo {}
+
 # List all known repositories
-c5t_list_repos {}
+list_repos {}
 # Shows: ID, remote identifier, local path, last accessed
 ```
 
@@ -269,47 +290,76 @@ c5t_list_repos {}
 - Prefix: `"auth*"` (matches authentication, authorize, etc.)
 - NOT: `"api NOT deprecated"`
 
+## Export/Import
+
+### Backup Your Data
+
+```bash
+# Export all data to timestamped backup file
+export_data {}
+# -> Saves to ~/.local/share/c5t/backups/backup-YYYYMMDD-HHMMSS.json
+
+# List available backups
+list_backups {}
+```
+
+### Restore Data
+
+```bash
+# Import from a backup (replaces all existing data)
+import_data {"filename": "backup-20251218-114006.json"}
+```
+
+**Note**: Import replaces all existing data. The backup format (v2.0) includes repositories, task lists, tasks, and notes with proper ID mapping.
+
 ## Examples
 
 **End-to-end workflow:**
 
 ```bash
-# 1. Create list for feature work
+# 1. Register the repository
+upsert_repo {}
+
+# 2. Create list for feature work
 upsert_task_list {"name": "Auth Feature", "tags": ["backend"]}
-# → ID: 1
+# -> ID: 1
 
-# 2. Add tasks one at a time as you discover them
+# 3. Add tasks one at a time as you discover them
 upsert_task {"list_id": 1, "content": "Research JWT", "priority": 1}
-# → ID: 1
+# -> ID: 1
 upsert_task {"list_id": 1, "content": "Implement login", "priority": 1}
-# → ID: 2
+# -> ID: 2
 upsert_task {"list_id": 1, "content": "Write tests", "priority": 2}
-# → ID: 3
+# -> ID: 3
 
-# 3. Break down complex tasks with subtasks
+# 4. Break down complex tasks with subtasks
 upsert_task {"list_id": 1, "parent_id": 2, "content": "Add /login endpoint"}
 upsert_task {"list_id": 1, "parent_id": 2, "content": "Add password validation"}
 
-# 4. Track progress - update status via upsert_task
+# 5. Track progress - update status via upsert_task
 upsert_task {"list_id": 1, "task_id": 1, "status": "done"}
 
 # Add progress notes to the list
 upsert_task_list {"list_id": 1, "notes": "Decided on jsonwebtoken crate"}
 
-# 5. Complete remaining tasks
+# 6. Complete remaining tasks
 complete_task {"list_id": 1, "task_id": 2}
 complete_task {"list_id": 1, "task_id": 3}
 
-# 6. Create reference notes
+# 7. Create reference notes
 upsert_note {"title": "JWT Best Practices", "content": "...", "tags": ["security"]}
 
-# 7. Search later
+# 8. Search later
 search {"query": "jwt AND security"}
+
+# 9. Backup your work
+export_data {}
 ```
 
 ## Notes
 
 - Database auto-initializes on first tool call
+- Repository must be registered before creating lists/notes
 - IDs are auto-generated integers (SQLite rowid)
 - Tags stored as JSON arrays
 - Timestamps in ISO format


### PR DESCRIPTION
## Summary

Updates c5t documentation to reflect the current state after the major refactoring in PR #71.

## Changes

### README.md
- Updated all 20 tool names to current naming (task_list, task, etc.)
- Removed references to removed features (auto-archive, scratchpad)
- Added subtask documentation with examples
- Added export/import documentation
- Updated project isolation examples with correct parameter names
- Fixed all code examples to use current API

### Implementation Plan
- Marked all milestones as COMPLETE
- Updated schema to reflect current database structure
- Added table of all 20 available tools
- Documented key changes from original plan
- Simplified document by removing outdated detailed milestones
- Updated testing section (52 tests)