### PR TITLE
feat(c5t): implement archive_task_list tool

### DIFF
--- a/tools/c5t/README.md
+++ b/tools/c5t/README.md
@@ -70,6 +70,15 @@ complete_task {"list_id": 1, "task_id": 1}
 
 # Add progress notes to the list
 upsert_task_list {"list_id": 1, "notes": "## Progress\n\nCompleted research"}
+
+# Archive a completed list (sets status='archived', records timestamp)
+archive_task_list {"list_id": 1}
+
+# View archived lists
+list_task_lists {"status": "archived"}
+
+# View all lists (active and archived)
+list_task_lists {"status": "all"}
 ```
 
 **Statuses**: `backlog`, `todo`, `in_progress`, `review`, `done`, `cancelled`
@@ -107,6 +116,38 @@ list_tasks {"list_id": 1}
 - Parent tasks show subtask count in task lists
 - Use `list_tasks` with `parent_id` to view subtasks for a specific parent
 - Deleting a parent task cascades to delete all subtasks
+
+## Archiving Task Lists
+
+Archive completed task lists to keep your workspace clean while preserving history:
+
+```bash
+# Archive a completed list
+archive_task_list {"list_id": "abc12345"}
+
+# List only active lists (default behavior)
+list_task_lists {}
+
+# List only archived lists
+list_task_lists {"status": "archived"}
+
+# List all lists (active and archived)
+list_task_lists {"status": "all"}
+```
+
+**How archiving works:**
+- Sets list `status` to 'archived'
+- Records `archived_at` timestamp
+- Archived lists are excluded from default `list_task_lists` output
+- Tasks within archived lists remain accessible
+- Archiving is idempotent (can archive an already-archived list)
+- Use `status` parameter to view archived lists
+
+**Why archive instead of delete:**
+- Preserves work history and completed tasks
+- Keeps your active list view clean
+- Can be synced across machines (unlike deleted data)
+- No risk of accidental data loss
 
 ## Notes Workflow
 
@@ -209,6 +250,7 @@ Last updated: [timestamp]
 - `upsert_task_list` - Create or update a list (omit list_id to create, provide to update). Supports name, description, tags, and progress notes.
 - `list_task_lists` - List task lists with status counts
 - `get_task_list` - Get list metadata without tasks
+- `archive_task_list` - Archive a list (sets status='archived', excluded from default views)
 - `delete_task_list` - Remove a list (use force=true if has tasks)
 
 ### Tasks

--- a/tools/c5t/mod.nu
+++ b/tools/c5t/mod.nu
@@ -153,6 +153,20 @@ def "main list-tools" [] {
     }
 
     {
+      name: "archive_task_list"
+      description: "Archive a task list by setting status to 'archived' and recording the archived timestamp. Archived lists are excluded from default list views but can be retrieved with status filter."
+      input_schema: {
+        type: "object"
+        properties: {
+          list_id: {
+            type: "string"
+            description: "ID of the task list to archive"
+          }
+        }
+        required: ["list_id"]
+      }
+    }
+    {
       name: "delete_task_list"
       description: "Remove a task list. Use force=true to delete list with tasks, otherwise fails if list has tasks."
       input_schema: {
@@ -637,6 +651,22 @@ def "main call-tool" [
       }
 
       $"✓ Task deleted \(ID: ($task_id)\)"
+    }
+
+    "archive_task_list" => {
+      if "list_id" not-in $parsed_args {
+        return "Error: Missing required field: 'list_id'"
+      }
+
+      let list_id = $parsed_args.list_id
+
+      let result = archive-task-list $list_id
+
+      if not $result.success {
+        return $result.error
+      }
+
+      $"✓ Task list archived \(ID: ($list_id)\)"
     }
 
     "delete_task_list" => {


### PR DESCRIPTION
## Summary

Implements the missing archive functionality for task lists using Test-Driven Development (TDD).

## Problem

The database schema had an `archived_at` column and `status IN ('active', 'archived')` constraint, but:
- No code ever set `archived_at`
- No MCP tool to archive lists
- Incomplete feature left as technical debt

## Solution

Added complete archive functionality:

### Storage Layer
- **`archive-task-list`** function in `storage.nu`
  - Sets `status='archived'` and `archived_at` timestamp
  - Idempotent (preserves original timestamp if already archived)
  - Error handling for missing lists

### MCP Tool
- **`archive_task_list`** tool in `mod.nu`
  - Simple interface: just `list_id` required
  - User-friendly success messages

### Tests
- 3 comprehensive tests covering:
  - Happy path (sets archived_at and status)
  - Error handling (list not found)
  - Idempotency (can archive already-archived list)
- **All 111/111 tests passing** ✅

### Documentation
- Added to Available Tools list
- Examples in Task Workflow section
- Dedicated "Archiving Task Lists" section explaining:
  - How archiving works
  - Why archive instead of delete
  - Viewing archived vs active lists

## Changes

```
4 files changed, 184 insertions(+)
```

- `tools/c5t/storage.nu` - archive-task-list function
- `tools/c5t/mod.nu` - archive_task_list MCP tool
- `tools/c5t/tests/test_task_schema.nu` - 3 new tests
- `tools/c5t/README.md` - archiving documentation

## Testing

```
Results: 111/111 passed, 0 failed
```

All existing tests continue to pass + 3 new archive tests.

## TDD Process

1. ✅ **RED**: Wrote failing tests first
2. ✅ **GREEN**: Implemented function to pass tests
3. ✅ **REFACTOR**: Formatted with topiary
4. ✅ **INTEGRATE**: Added MCP tool and docs
5. ✅ **VERIFY**: All tests passing

## Benefits

- Completes the partially-implemented archive feature
- Preserves work history without cluttering active lists
- Sync-compatible (JSONL export/import preserves archived_at)
- Clean separation between active and archived lists

## Checklist

- [x] Tests written first (TDD)
- [x] All tests passing (111/111)
- [x] Code formatted with topiary
- [x] Documentation updated
- [x] Examples provided
- [x] Idempotent design
- [x] Error handling
