### PR TITLE
feat(c5t): add status parameter to list_task_lists and remove last_accessed_at

### DIFF
--- a/tools/c5t/README.md
+++ b/tools/c5t/README.md
@@ -391,7 +391,7 @@ sync_export {"message": "Added new auth tasks"}
 c5t uses **last-write-wins** based on `updated_at` timestamps:
 - When importing, if a record exists locally and in sync files, the newer one wins
 - Tasks use `completed_at` for comparison
-- Repos use `last_accessed_at`
+- Repos are overwritten (path is just metadata, identity is by remote)
 
 ### Sync Tools
 

--- a/tools/c5t/formatters.nu
+++ b/tools/c5t/formatters.nu
@@ -37,13 +37,24 @@ export def format-list-created [result: record] {
   ] | str join (char newline)
 }
 
-# Format active task lists as markdown table
-export def format-active-lists [lists: list] {
+# Format task lists as markdown table with status-aware header
+export def format-task-lists [lists: list status: string = "active"] {
   if ($lists | is-empty) {
-    return "No active task lists found."
+    return (
+      match $status {
+        "active" => "No active task lists found."
+        "archived" => "No archived task lists found."
+        _ => "No task lists found."
+      }
+    )
   }
 
-  let header = $"# Active Task Lists \(($lists | length)\)\n\n"
+  let header_label = match $status {
+    "active" => "Active"
+    "archived" => "Archived"
+    _ => "All"
+  }
+  let header = $"# ($header_label) Task Lists \(($lists | length)\)\n\n"
 
   let table_data = $lists | each {|list|
       let tags_str = if ($list.tags | is-not-empty) {

--- a/tools/c5t/mod.nu
+++ b/tools/c5t/mod.nu
@@ -61,6 +61,11 @@ def "main list-tools" [] {
       input_schema: {
         type: "object"
         properties: {
+          status: {
+            type: "string"
+            enum: ["active" "archived" "all"]
+            description: "Filter lists by status: 'active' (default), 'archived', or 'all'"
+          }
           tags: {
             type: "array"
             items: {type: "string"}
@@ -539,16 +544,17 @@ def "main call-tool" [
     }
 
     "list_task_lists" => {
+      let status = if "status" in $parsed_args { $parsed_args.status } else { "active" }
       let tag_filter = if "tags" in $parsed_args { $parsed_args.tags } else { null }
       let all_repos = if "all_repos" in $parsed_args { $parsed_args.all_repos } else { false }
       let repo_id = if "repo_id" in $parsed_args { $parsed_args.repo_id } else { null }
 
       let result = if $all_repos {
-        get-task-lists --status "active" --all-repos
+        get-task-lists --status $status --all-repos
       } else if $repo_id != null {
-        get-task-lists --status "active" --repo-id $repo_id
+        get-task-lists --status $status --repo-id $repo_id
       } else {
-        get-task-lists --status "active"
+        get-task-lists --status $status
       }
 
       if not $result.success {
@@ -565,7 +571,7 @@ def "main call-tool" [
         $result.lists
       }
 
-      format-active-lists $filtered
+      format-task-lists $filtered $status
     }
 
     "upsert_task" => {

--- a/tools/c5t/sql/0001_initial_schema.sql
+++ b/tools/c5t/sql/0001_initial_schema.sql
@@ -8,8 +8,7 @@ CREATE TABLE IF NOT EXISTS repo (
     id TEXT PRIMARY KEY CHECK(length(id) == 8),
     remote TEXT UNIQUE NOT NULL,        -- e.g. "github:ck3mp3r/nu-mcp"
     path TEXT,                          -- local absolute path (last known)
-    created_at TEXT DEFAULT (datetime('now')),
-    last_accessed_at TEXT DEFAULT (datetime('now'))
+    created_at TEXT DEFAULT (datetime('now'))
 );
 
 -- Task List table - tracks collections of work items

--- a/tools/c5t/tests/mocks.nu
+++ b/tools/c5t/tests/mocks.nu
@@ -27,19 +27,8 @@ export def "query db" [
     }
   }
 
-  # Repository queries - check for last-accessed pattern first
+  # Repository queries
   if ($sql | str contains "FROM repo") {
-    # Last-accessed repo query (LIMIT 1 with ORDER BY last_accessed_at)
-    if ($sql | str contains "ORDER BY last_accessed_at DESC LIMIT 1") {
-      if "MOCK_query_db_REPO_LAST_ACCESSED" in $env {
-        let mock_data = $env | get MOCK_query_db_REPO_LAST_ACCESSED
-        if $mock_data.exit_code != 0 {
-          error make {msg: $"SQLite error: ($mock_data.error)"}
-        }
-        return $mock_data.output
-      }
-    }
-    # General repo queries
     if "MOCK_query_db_REPO" in $env {
       let mock_data = $env | get MOCK_query_db_REPO
       if $mock_data.exit_code != 0 {

--- a/tools/c5t/tests/test_formatters.nu
+++ b/tools/c5t/tests/test_formatters.nu
@@ -13,8 +13,8 @@ export def "test format-list-created formats output" [] {
   assert ($output | str contains "1234")
 }
 
-export def "test format-active-lists formats output" [] {
-  use ../formatters.nu format-active-lists
+export def "test format-task-lists formats output" [] {
+  use ../formatters.nu format-task-lists
 
   let lists = [
     {
@@ -28,16 +28,16 @@ export def "test format-active-lists formats output" [] {
     }
   ]
 
-  let output = format-active-lists $lists
+  let output = format-task-lists $lists "active"
 
   assert ($output | str contains "Sprint Tasks")
   assert ($output | str contains "sprint")
 }
 
-export def "test format-active-lists handles empty" [] {
-  use ../formatters.nu format-active-lists
+export def "test format-task-lists handles empty" [] {
+  use ../formatters.nu format-task-lists
 
-  let output = format-active-lists []
+  let output = format-task-lists [] "active"
   assert ($output | str contains "No active")
 }
 
@@ -239,4 +239,54 @@ export def "test format-item-updated accepts string id" [] {
   let output = format-item-updated "status" "ghi11111" "done"
   assert ($output | str contains "ghi11111") "Should contain item ID"
   assert ($output | str contains "status") "Should contain field name"
+}
+
+# --- format-task-lists tests (renamed from format-active-lists) ---
+
+export def "test format-task-lists active header" [] {
+  use ../formatters.nu format-task-lists
+
+  let lists = [{id: "abc12345" name: "Test List" tags: [] description: "" external_ref: null}]
+  let output = format-task-lists $lists "active"
+
+  assert ($output | str starts-with "# Active Task Lists")
+}
+
+export def "test format-task-lists archived header" [] {
+  use ../formatters.nu format-task-lists
+
+  let lists = [{id: "abc12345" name: "Test List" tags: [] description: "" external_ref: null}]
+  let output = format-task-lists $lists "archived"
+
+  assert ($output | str starts-with "# Archived Task Lists")
+}
+
+export def "test format-task-lists all header" [] {
+  use ../formatters.nu format-task-lists
+
+  let lists = [{id: "abc12345" name: "Test List" tags: [] description: "" external_ref: null}]
+  let output = format-task-lists $lists "all"
+
+  assert ($output | str starts-with "# All Task Lists")
+}
+
+export def "test format-task-lists empty active" [] {
+  use ../formatters.nu format-task-lists
+
+  let output = format-task-lists [] "active"
+  assert ($output == "No active task lists found.")
+}
+
+export def "test format-task-lists empty archived" [] {
+  use ../formatters.nu format-task-lists
+
+  let output = format-task-lists [] "archived"
+  assert ($output == "No archived task lists found.")
+}
+
+export def "test format-task-lists empty all" [] {
+  use ../formatters.nu format-task-lists
+
+  let output = format-task-lists [] "all"
+  assert ($output == "No task lists found.")
 }

--- a/tools/c5t/tests/test_mod.nu
+++ b/tools/c5t/tests/test_mod.nu
@@ -132,3 +132,16 @@ export def "test get_summary schema has repo_id" [] {
   assert ("repo_id" in ($tool.input_schema.properties | columns))
   assert ($tool.input_schema.properties.repo_id.type == "string")
 }
+
+# --- status parameter tests ---
+
+# Test list_task_lists schema has status parameter with enum
+export def "test list_task_lists schema has status" [] {
+  let output = nu tools/c5t/mod.nu list-tools
+  let tools = $output | from json
+  let tool = $tools | where name == "list_task_lists" | first
+
+  assert ("status" in ($tool.input_schema.properties | columns))
+  assert ($tool.input_schema.properties.status.type == "string")
+  assert ($tool.input_schema.properties.status.enum == ["active" "archived" "all"])
+}

--- a/tools/c5t/tests/test_schema_v2.nu
+++ b/tools/c5t/tests/test_schema_v2.nu
@@ -214,3 +214,19 @@ export def "test subtask foreign key to parent task works" [] {
     assert ($subtasks.0.parent_id == "d4e5f6a7") "Parent ID should be TEXT"
   }
 }
+
+# ============================================================================
+# SCHEMA CLEANUP TESTS
+# ============================================================================
+
+# Test that repo table does NOT have last_accessed_at column
+export def "test repo table has no last_accessed_at" [] {
+  with-test-db {
+    let db_path = init-database
+
+    let table_info = open $db_path | query db "PRAGMA table_info(repo)"
+    let col_names = $table_info | get name
+
+    assert ("last_accessed_at" not-in $col_names) "repo table should not have last_accessed_at column"
+  }
+}

--- a/tools/c5t/tests/test_sync.nu
+++ b/tools/c5t/tests/test_sync.nu
@@ -156,7 +156,7 @@ export def "test write-sync-files creates jsonl files" [] {
   let sync_dir = ($temp_dir | path join "sync")
 
   let data = {
-    repos: [{id: "repo1234" remote: "git@github.com:test/repo" path: "/path" created_at: "2025-01-01" last_accessed_at: "2025-01-01"}]
+    repos: [{id: "repo1234" remote: "git@github.com:test/repo" path: "/path" created_at: "2025-01-01"}]
     lists: [{id: "list1234" repo_id: "repo1234" name: "Test" description: "Desc" tags: "tag1" notes: null external_ref: null created_at: "2025-01-01" updated_at: "2025-01-01"}]
     tasks: [{id: "task1234" list_id: "list1234" content: "Task" priority: 3 status: "todo" parent_id: null created_at: "2025-01-01" updated_at: "2025-01-01" started_at: null completed_at: null}]
     notes: [{id: "note1234" repo_id: "repo1234" title: "Note" content: "Content" tags: "" note_type: "manual" created_at: "2025-01-01" updated_at: "2025-01-01"}]
@@ -181,7 +181,7 @@ export def "test read-sync-files reads jsonl files" [] {
   let sync_dir = ($temp_dir | path join "sync")
 
   let data = {
-    repos: [{id: "repo1234" remote: "git@github.com:test/repo" path: "/path" created_at: "2025-01-01" last_accessed_at: "2025-01-01"}]
+    repos: [{id: "repo1234" remote: "git@github.com:test/repo" path: "/path" created_at: "2025-01-01"}]
     lists: [{id: "list1234" repo_id: "repo1234" name: "Test" description: "Desc" tags: "tag1" notes: null external_ref: null created_at: "2025-01-01" updated_at: "2025-01-01"}]
     tasks: [{id: "task1234" list_id: "list1234" content: "Task" priority: 3 status: "todo" parent_id: null created_at: "2025-01-01" updated_at: "2025-01-01" started_at: null completed_at: null}]
     notes: [{id: "note1234" repo_id: "repo1234" title: "Note" content: "Content" tags: "" note_type: "manual" created_at: "2025-01-01" updated_at: "2025-01-01"}]
@@ -288,7 +288,7 @@ export def "test import-sync-to-db imports new records" [] {
 
     # Create sync files with test data
     let data = {
-      repos: [{id: "testrepo" remote: "github:test/repo" path: "/test/path" created_at: "2025-01-01T00:00:00Z" last_accessed_at: "2025-01-01T00:00:00Z"}]
+      repos: [{id: "testrepo" remote: "github:test/repo" path: "/test/path" created_at: "2025-01-01T00:00:00Z"}]
       lists: [{id: "testlist" repo_id: "testrepo" name: "Imported List" description: "Imported" tags: "" notes: null status: "active" external_ref: null created_at: "2025-01-01T00:00:00Z" updated_at: "2025-01-01T00:00:00Z" archived_at: null}]
       tasks: [{id: "testtask" list_id: "testlist" content: "Imported Task" priority: 3 status: "todo" parent_id: null created_at: "2025-01-01T00:00:00Z" started_at: null completed_at: null}]
       notes: [{id: "testnote" repo_id: "testrepo" title: "Imported Note" content: "Content" tags: "" note_type: "manual" created_at: "2025-01-01T00:00:00Z" updated_at: "2025-01-01T00:00:00Z"}]
@@ -337,7 +337,7 @@ export def "test import-sync-to-db updates existing with newer timestamp" [] {
 
   # Create sync files with newer data (future timestamp)
   let data = {
-    repos: [{id: $repo.repo_id remote: $repo.remote path: $repo.path created_at: "2025-01-01T00:00:00Z" last_accessed_at: "2025-01-01T00:00:00Z"}]
+    repos: [{id: $repo.repo_id remote: $repo.remote path: $repo.path created_at: "2025-01-01T00:00:00Z"}]
     lists: [{id: $list.id repo_id: $repo.repo_id name: "New Name" description: "New Desc" tags: "" notes: null status: "active" external_ref: null created_at: "2025-01-01T00:00:00Z" updated_at: "2099-01-01T00:00:00Z" archived_at: null}]
     tasks: []
     notes: []
@@ -498,7 +498,7 @@ export def "test sync-refresh imports data from sync files" [] {
 
   # Write sync data directly (simulating a pull from remote)
   let data = {
-    repos: [{id: "testrepo" remote: "github:test/repo" path: "/test/path" created_at: "2025-01-01T00:00:00Z" last_accessed_at: "2025-01-01T00:00:00Z"}]
+    repos: [{id: "testrepo" remote: "github:test/repo" path: "/test/path" created_at: "2025-01-01T00:00:00Z"}]
     lists: []
     tasks: []
     notes: []


### PR DESCRIPTION
## Summary

Adds `status` parameter to `list_task_lists` tool and removes unused `last_accessed_at` column from repo table.

## Changes

### Status Parameter for list_task_lists
- Add `status` parameter to tool schema with enum: `active`, `archived`, `all` (default: `active`)
- Rename `format-active-lists` to `format-task-lists` with dynamic header based on status
- Update call-tool to pass status through to storage and formatter

### Schema Cleanup - Remove last_accessed_at
- Remove `last_accessed_at` column from repo table schema
- Remove unused `get-last-accessed-repo` function
- Update `list-repos` to order by `remote ASC` (alphabetical)
- Simplify sync import logic for repos (simple overwrite instead of timestamp comparison)
- Update test fixtures and mocks

## Testing

- All 119 tests pass
- Manual testing verified all three status values work correctly