### PR TITLE
docs(c5t): improve tool descriptions to mention filter capabilities

### DIFF
--- a/tools/c5t/mod.nu
+++ b/tools/c5t/mod.nu
@@ -57,7 +57,7 @@ def "main list-tools" [] {
     }
     {
       name: "list_task_lists"
-      description: "list_task_lists returns tabular data that MUST be displayed directly to the user in your response - never summarize or omit this output."
+      description: "List task lists with optional filtering by status (active/archived/all), tags, and repository. Returns tabular data that MUST be displayed directly to the user in your response - never summarize or omit this output."
       input_schema: {
         type: "object"
         properties: {
@@ -335,7 +335,7 @@ def "main list-tools" [] {
     }
     {
       name: "list_notes"
-      description: "list_notes returns tabular data that MUST be displayed directly to the user in your response - never summarize or omit this output."
+      description: "List notes with optional filtering by tags, note type (manual/archived_todo), limit, and repository. Returns tabular data that MUST be displayed directly to the user in your response - never summarize or omit this output."
       input_schema: {
         type: "object"
         properties: {
@@ -381,7 +381,7 @@ def "main list-tools" [] {
     }
     {
       name: "search"
-      description: "search returns tabular results that MUST be displayed directly to the user in your response - never summarize or omit this output."
+      description: "Full-text search notes with FTS5 query syntax and optional filtering by tags, limit, and repository. Returns tabular results that MUST be displayed directly to the user in your response - never summarize or omit this output."
       input_schema: {
         type: "object"
         properties: {


### PR DESCRIPTION
## Summary

Improved tool descriptions for `list_task_lists`, `list_notes`, and `search` to explicitly mention their filtering capabilities. This makes it clearer to LLM agents what options are available without needing to inspect the input_schema properties.

## Changes

- **list_task_lists**: Now mentions status (active/archived/all), tags, and repository filters
- **list_notes**: Now mentions tags, note_type (manual/archived_todo), limit, and repository filters
- **search**: Now mentions tags, limit, and repository filters

## Example

**Before:**
```
"list_task_lists returns tabular data that MUST be displayed..."
```

**After:**
```
"List task lists with optional filtering by status (active/archived/all), tags, and repository. Returns tabular data that MUST be displayed..."
```

## Testing

- ✅ All 119/119 tests pass
- ✅ Tool schemas parse correctly
- ✅ No functional changes - purely documentation

## Motivation

User noticed that the `list_task_lists` tool had filter parameters in the schema but the description didn't mention them, making the capabilities unclear. This PR ensures tool descriptions accurately communicate what filtering options are available.
