### PR TITLE
fix(k8s): make 'name' parameter optional in kube_logs when using labelSelector

### DIFF
--- a/tools/k8s/formatters.nu
+++ b/tools/k8s/formatters.nu
@@ -158,7 +158,6 @@ export def kubectl-logs-schema [] {
         context: (context-parameter)
         delegate: (delegate-parameter)
       }
-      required: ["name"]
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes a bug where `kube_logs` required the `name` parameter even when using `labelSelector`, causing the error: `Cannot find column 'name'`.

## Problem

When trying to get logs using a label selector (e.g., `labelSelector=app=tekton-pruner-controller`), the tool crashed because:
1. The schema marked `name` as required
2. The implementation tried to access `$params.name` which didn't exist
3. kubectl supports `--selector` flag without requiring a pod name

## Changes

### Schema (formatters.nu)
- Removed `required: ["name"]` from `kube_logs` schema
- Both `name` and `labelSelector` are now optional

### Implementation (logs.nu)
- Changed `name` default from crashing access to empty string `""`  (consistent with other string parameters)
- Added validation: require either `name` OR `labelSelector` (not both empty)
- Updated response formatting to conditionally include `name`, `labelSelector`, and `container`
- Maintained consistency: all string params default to `""`, checked with `!= ""`

## Testing

**Manual validation:**
```bash
# With labelSelector (no name) - generates correct command
nu tools/k8s/mod.nu call-tool kube_logs '{"labelSelector": "app=test", "delegate": true}'
# Output: kubectl logs --selector app=test --namespace default

# With name (no labelSelector) - still works
nu tools/k8s/mod.nu call-tool kube_logs '{"name": "my-pod", "delegate": true}'
# Output: kubectl logs my-pod --namespace default

# Without either - proper validation error
nu tools/k8s/mod.nu call-tool kube_logs '{}'
# Error: Either 'name' or 'labelSelector' parameter is required
```

## Example Usage

```javascript
// Get logs by label selector
await client.callTool("kube_logs", {
  labelSelector: "app=tekton-pruner-controller",
  namespace: "tekton-pipelines",
  tail: 50
});

// Get logs by pod name (still works)
await client.callTool("kube_logs", {
  name: "my-pod-12345",
  namespace: "default"
});
```

## Impact

- ✅ Fixes the reported bug with labelSelector
- ✅ Maintains backward compatibility for name-based queries
- ✅ Improves error messages with clear validation
- ✅ Consistent parameter handling across k8s tools
