### PR TITLE
fix(execution): prevent stdin blocking by closing stdin

### DIFF
--- a/src/execution/nushell.rs
+++ b/src/execution/nushell.rs
@@ -1,6 +1,6 @@
 use super::CommandExecutor;
 use async_trait::async_trait;
-use std::{env, path::Path, time::Duration};
+use std::{env, path::Path, process::Stdio, time::Duration};
 use tokio::process::Command;
 use tokio::time::timeout;
 
@@ -34,6 +34,7 @@ impl CommandExecutor for NushellExecutor {
             .arg("-c")
             .arg(command)
             .current_dir(working_dir)
+            .stdin(Stdio::null()) // Prevent blocking on stdin
             .output();
 
         // Apply timeout wrapper


### PR DESCRIPTION
## Summary

Commands that wait for stdin (like `cat`, `input`) would previously block indefinitely because stdin was inherited from the parent process. This could cause the entire agent/OpenCode process to hang when waiting for a response from the MCP tool.

## Fix

Sets `stdin` to `Stdio::null()` so commands cannot block waiting for input that will never come.

## Changes

- `src/execution/nushell.rs`: Added `.stdin(Stdio::null())` to the Command builder
- `src/execution/nushell_test.rs`: Added 2 new tests:
  - `test_nushell_executor_stdin_closed_prevents_blocking` - verifies commands like `cat` complete instantly instead of blocking
  - `test_nushell_executor_timeout_kills_long_running_process` - verifies infinite loops are properly killed by timeout

## Testing

All 93 tests pass.

## Notes

The existing `tokio::time::timeout()` wrapper around `.output()` was already working correctly for timeout enforcement. The issue was that commands waiting for stdin would block before producing output, which the timeout could not help with. Closing stdin preemptively solves this.