### PR TITLE
fix: update rustnix API usage - remove fenix parameter

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -74,11 +74,11 @@
       },
       "locked": {
         "dir": "base-nixpkgs",
-        "lastModified": 1780158994,
-        "narHash": "sha256-WiwvzxvICOpu/A4FVw8h3cgux0aFzBUmhfopiDwz74A=",
+        "lastModified": 1780190992,
+        "narHash": "sha256-SjE3heUSCc/+3nVFMd1DyKwolLD7JBrgqD34y9XUpZM=",
         "owner": "ck3mp3r",
         "repo": "flakes",
-        "rev": "ab1939fe920bb00c98029f66e84e62623a19449f",
+        "rev": "fe44022fff060081989cdc07c00cea0ec3b3a5f9",
         "type": "github"
       },
       "original": {
@@ -116,6 +116,28 @@
           "nixpkgs"
         ],
         "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1780130272,
+        "narHash": "sha256-iCNBDsTLvD5pK9xCbd/Kl4NabrLRws6WVkiElGM9U1Q=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "2118601eb824d47529307266d74e68dfd661c236",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "fenix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "rustnix",
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src_2"
       },
       "locked": {
         "lastModified": 1780130272,
@@ -490,12 +512,27 @@
         "type": "github"
       }
     },
+    "rust-analyzer-src_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1780060635,
+        "narHash": "sha256-k+iiE7EUc732hT7u1YP3omk9rCElKBbc5evooZSskwU=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "5ebf65ce47fc047e8a2772297f2ddd988ab86c32",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
     "rustnix": {
       "inputs": {
         "base-nixpkgs": "base-nixpkgs_4",
-        "fenix": [
-          "fenix"
-        ],
+        "fenix": "fenix_2",
         "flake-parts": "flake-parts_8",
         "nixpkgs": [
           "nixpkgs"
@@ -503,11 +540,11 @@
       },
       "locked": {
         "dir": "rustnix",
-        "lastModified": 1780190992,
-        "narHash": "sha256-SjE3heUSCc/+3nVFMd1DyKwolLD7JBrgqD34y9XUpZM=",
+        "lastModified": 1780199268,
+        "narHash": "sha256-vsc3rpW1ualn1TOAbaIv/iVhZFJD7PkcvCIKyAVClfw=",
         "owner": "ck3mp3r",
         "repo": "flakes",
-        "rev": "fe44022fff060081989cdc07c00cea0ec3b3a5f9",
+        "rev": "acae6c54d1ff6f72f576f6f89bd456f7dcdae3ad",
         "type": "github"
       },
       "original": {
@@ -567,11 +604,11 @@
     },
     "stable_4": {
       "locked": {
-        "lastModified": 1780157875,
-        "narHash": "sha256-h22F7jNHYoLoae5uObWnTemVJDiMhpPV8AeWMZc2yx8=",
+        "lastModified": 1780180721,
+        "narHash": "sha256-bHHvsVgzvOE0SKJn2OB7LDKuiOpdkXS/eVqTiJDNVBI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "30b7e6c47a9ddc49e777e8d2b1266ca48c7c5979",
+        "rev": "9396caa0b59af6a17cac62008a72255b25e1e9a8",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -113,31 +113,10 @@
     "fenix": {
       "inputs": {
         "nixpkgs": [
-          "nixpkgs"
-        ],
-        "rust-analyzer-src": "rust-analyzer-src"
-      },
-      "locked": {
-        "lastModified": 1780130272,
-        "narHash": "sha256-iCNBDsTLvD5pK9xCbd/Kl4NabrLRws6WVkiElGM9U1Q=",
-        "owner": "nix-community",
-        "repo": "fenix",
-        "rev": "2118601eb824d47529307266d74e68dfd661c236",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "fenix",
-        "type": "github"
-      }
-    },
-    "fenix_2": {
-      "inputs": {
-        "nixpkgs": [
           "rustnix",
           "nixpkgs"
         ],
-        "rust-analyzer-src": "rust-analyzer-src_2"
+        "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
         "lastModified": 1780130272,
@@ -484,7 +463,6 @@
     "root": {
       "inputs": {
         "base-nixpkgs": "base-nixpkgs",
-        "fenix": "fenix",
         "flake-parts": "flake-parts_2",
         "nixpkgs": [
           "base-nixpkgs",
@@ -512,27 +490,10 @@
         "type": "github"
       }
     },
-    "rust-analyzer-src_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1780060635,
-        "narHash": "sha256-k+iiE7EUc732hT7u1YP3omk9rCElKBbc5evooZSskwU=",
-        "owner": "rust-lang",
-        "repo": "rust-analyzer",
-        "rev": "5ebf65ce47fc047e8a2772297f2ddd988ab86c32",
-        "type": "github"
-      },
-      "original": {
-        "owner": "rust-lang",
-        "ref": "nightly",
-        "repo": "rust-analyzer",
-        "type": "github"
-      }
-    },
     "rustnix": {
       "inputs": {
         "base-nixpkgs": "base-nixpkgs_4",
-        "fenix": "fenix_2",
+        "fenix": "fenix",
         "flake-parts": "flake-parts_8",
         "nixpkgs": [
           "nixpkgs"

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,6 @@
     rustnix = {
       url = "github:ck3mp3r/flakes?dir=rustnix";
       inputs.nixpkgs.follows = "nixpkgs";
-      inputs.fenix.follows = "fenix";
     };
     topiary-nu = {
       url = "github:ck3mp3r/flakes?dir=topiary-nu";
@@ -115,7 +114,6 @@
             installData
             supportedTargets
             ;
-          fenix = inputs.fenix;
           nixpkgs = inputs.nixpkgs;
           src = ./.;
           packageName = "nu-mcp";
@@ -134,7 +132,6 @@
             installData
             supportedTargets
             ;
-          fenix = inputs.fenix;
           nixpkgs = inputs.nixpkgs;
           src = ./.;
           packageName = "archive";

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Rust Nushell MCP Server with Devenv and Fenix";
+  description = "Rust Nushell MCP Server";
 
   inputs = {
     base-nixpkgs.url = "github:ck3mp3r/flakes?dir=base-nixpkgs";
@@ -7,10 +7,6 @@
     flake-parts = {
       url = "github:hercules-ci/flake-parts";
       inputs.nixpkgs-lib.follows = "nixpkgs";
-    };
-    fenix = {
-      url = "github:nix-community/fenix";
-      inputs.nixpkgs.follows = "nixpkgs";
     };
     rustnix = {
       url = "github:ck3mp3r/flakes?dir=rustnix";
@@ -40,11 +36,13 @@
       }: let
         supportedTargets = ["aarch64-darwin" "aarch64-linux" "x86_64-linux"];
         overlays = [
-          inputs.fenix.overlays.default
           inputs.topiary-nu.overlays.default
           inputs.base-nixpkgs.overlays.default
         ];
-        pkgs = import inputs.nixpkgs {inherit system overlays;};
+        pkgs = import inputs.nixpkgs {
+          localSystem = system;
+          inherit overlays;
+        };
 
         cargoToml = fromTOML (builtins.readFile ./Cargo.toml);
         cargoLock = {lockFile = ./Cargo.lock;};

--- a/nix/ci.nix
+++ b/nix/ci.nix
@@ -4,7 +4,7 @@
   inputs,
   system,
 }: let
-  fenix = inputs.fenix.packages.${system};
+  rustToolchain = inputs.rustnix.packages.${system}.toolchain;
 
   # Test runner script - uses auto-discovery
   runToolTests = pkgs.writeShellScriptBin "run-tool-tests" ''
@@ -16,7 +16,7 @@ in
 
     buildInputs = [
       # Rust toolchain (stable)
-      fenix.stable.toolchain
+      rustToolchain
 
       # Nushell for tool tests
       pkgs.nushell

--- a/nix/dev.nix
+++ b/nix/dev.nix
@@ -5,7 +5,7 @@
   inputs,
   ...
 }: let
-  fenix = inputs.fenix.packages.${pkgs.system};
+  rustToolchain = inputs.rustnix.packages.${pkgs.system}.toolchain;
   nuMods = inputs.nu-mods.packages.${pkgs.system}.default;
 
   # Development helper scripts
@@ -21,7 +21,7 @@ in
     name = "nu-mcp-dev";
 
     buildInputs = [
-      fenix.stable.toolchain
+      rustToolchain
       pkgs.nushell
       pkgs.cargo-tarpaulin
       pkgs.topiary-nu


### PR DESCRIPTION
rustnix has internalized fenix — `buildTargetOutputs` no longer accepts a `fenix` parameter.

### Changes
- Remove `fenix = inputs.fenix;` from both `buildTargetOutputs` calls
- Remove `inputs.fenix.follows` from rustnix input (rustnix manages its own fenix now)
- Keep fenix input — still used by dev/ci shells for `fenix.stable.toolchain`

### Verified
- `nix build` succeeds (exit code 0)