### PR TITLE
fix: use system-specific default package in overlay

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -170,7 +170,7 @@
 
       flake = {
         overlays.default = final: prev: {
-          nu-mcp = self.packages.default;
+          nu-mcp = self.packages.${final.system}.default;
         };
       };
     };


### PR DESCRIPTION
Fix the default Nix overlay by referencing the system-specific package output.

The overlay currently references:

```nix
self.packages.default
```

However, flake package outputs are system-specific, for example:

```nix
self.packages.x86_64-linux.default
self.packages.aarch64-linux.default
self.packages.aarch64-darwin.default
```

This causes overlay to fail during evaluation with:
```
error: attribute 'default' missing
```

Use final.system to select the package for the importing system:
```nix
self.packages.${final.system}.default
```